### PR TITLE
fix: validate SPRT test requests and stop leaking filesystem paths in errors

### DIFF
--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -8,12 +8,17 @@ including SPRT recovery.
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any, cast
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from shared.storage.file_store import (
     FileGameRepository,
     FileOpeningBookRepository,
@@ -32,6 +37,57 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_DATA_DIR = Path("data")
 _DEFAULT_RUNNER_PYTHON = "sprt-runner/.venv/bin/python"
+
+
+def _json_safe(value: Any) -> Any:
+    """Recursively replace non-finite floats with their string form.
+
+    Starlette's ``JSONResponse`` renders with ``allow_nan=False``
+    (spec-compliant JSON). A request validation error whose rejected
+    input was NaN/Infinity (e.g. an ``elo0`` guarded by
+    ``allow_inf_nan=False``) embeds that raw float in the error body
+    via ``jsonable_encoder``, which otherwise crashes serialisation of
+    the 422 response itself. Stringifying it keeps the response a
+    clean 422 instead of a 500.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return str(value)
+    if isinstance(value, dict):
+        mapping = cast("dict[Any, Any]", value)
+        return {key: _json_safe(item) for key, item in mapping.items()}
+    if isinstance(value, list):
+        items = cast("list[Any]", value)
+        return [_json_safe(item) for item in items]
+    return value
+
+
+async def _validation_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Render request validation errors as JSON, guarding non-finite floats.
+
+    Args:
+        request: The incoming request (required by FastAPI's handler
+            signature, unused here).
+        exc: The validation error raised by Pydantic/FastAPI. Typed as
+            ``Exception`` to match Starlette's ``ExceptionHandler``
+            signature; narrowed to :class:`RequestValidationError`
+            below since that is the only exception type this handler
+            is registered for.
+
+    Returns:
+        A 422 JSON response with sanitised error details.
+
+    Raises:
+        Exception: Re-raises ``exc`` unchanged if it is not a
+            :class:`RequestValidationError` (this handler is only ever
+            registered for that type, but ``assert`` would be a no-op
+            under ``python -O``, so the guard is an explicit ``raise``).
+    """
+    if not isinstance(exc, RequestValidationError):
+        raise exc
+    return JSONResponse(
+        status_code=422,
+        content={"detail": _json_safe(jsonable_encoder(exc.errors()))},
+    )
 
 
 @asynccontextmanager
@@ -84,6 +140,10 @@ def create_app(
         version="0.1.0",
         lifespan=lifespan,
     )
+
+    # Guard against non-finite floats (NaN/Infinity) crashing the 422
+    # response itself — see `_validation_exception_handler`.
+    app.add_exception_handler(RequestValidationError, _validation_exception_handler)
 
     # CORS
     origins = cors_origins or ["http://localhost:5173"]

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -7,8 +7,40 @@ JSON representations exchanged over HTTP and WebSocket.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
+from shared.time_control import parse_time_control
+
+# Upper bounds on request-supplied strings. These exist purely to keep
+# malformed/adversarial input from reaching `SPRTService.start_test`
+# (and from there, `argv` of the runner subprocess) — legitimate engine
+# ids and time control strings are always far shorter than this.
+_MAX_ENGINE_ID_LENGTH = 256
+_MAX_TIME_CONTROL_LENGTH = 128
+
+# Elo bounds are kept within a wide but finite range so an accepted
+# value can never overflow `sprt_runner`'s logistic Elo model (which
+# starts raising ``OverflowError`` around +/-123281).
+_MIN_ELO = -1000.0
+_MAX_ELO = 1000.0
+
+
+def _has_non_printable(value: str) -> bool:
+    """Return ``True`` if any character in ``value`` is non-printable.
+
+    Catches control characters (e.g. NUL, newline) and Unicode format
+    characters (e.g. zero-width space, byte-order mark) that would
+    otherwise ride along into ``argv`` of the SPRT runner subprocess.
+
+    Args:
+        value: The string to check.
+
+    Returns:
+        Whether any character fails ``str.isprintable()``.
+    """
+    return any(not ch.isprintable() for ch in value)
+
 
 # ---------------------------------------------------------------------------
 # Time control
@@ -92,15 +124,121 @@ class GameSummaryResponse(BaseModel):
 class SPRTTestCreateRequest(BaseModel):
     """Request body for POST /sprt/tests."""
 
-    engine_a: str
-    engine_b: str
-    time_control: str = Field(description="Time control string, e.g. 'movetime=1000'")
-    elo0: float = 0.0
-    elo1: float = 5.0
-    alpha: float = 0.05
-    beta: float = 0.05
+    engine_a: str = Field(max_length=_MAX_ENGINE_ID_LENGTH, description="First engine identifier")
+    engine_b: str = Field(max_length=_MAX_ENGINE_ID_LENGTH, description="Second engine identifier")
+    time_control: str = Field(
+        max_length=_MAX_TIME_CONTROL_LENGTH,
+        description="Time control string, e.g. 'movetime=1000'",
+    )
+    elo0: float = Field(
+        default=0.0,
+        ge=_MIN_ELO,
+        le=_MAX_ELO,
+        allow_inf_nan=False,
+        description="Null-hypothesis Elo bound",
+    )
+    elo1: float = Field(
+        default=5.0,
+        ge=_MIN_ELO,
+        le=_MAX_ELO,
+        allow_inf_nan=False,
+        description="Alternative-hypothesis Elo bound",
+    )
+    alpha: float = Field(
+        default=0.05, gt=0, lt=1, allow_inf_nan=False, description="Type-I error rate"
+    )
+    beta: float = Field(
+        default=0.05, gt=0, lt=1, allow_inf_nan=False, description="Type-II error rate"
+    )
     book_id: str | None = None
-    concurrency: int = 1
+    concurrency: int = Field(default=1, ge=1, le=64, description="Number of concurrent workers")
+
+    @field_validator("engine_a", "engine_b")
+    @classmethod
+    def _strip_and_require_nonempty(cls, value: str) -> str:
+        """Reject blank, whitespace-only, or non-printable engine identifiers.
+
+        Whitespace is stripped and re-checked here (bare ``min_length``
+        would accept ``"   "``); the stripped value is what gets stored
+        and forwarded to the runner. Non-printable characters (control
+        characters, zero-width/format characters) are rejected outright
+        so they cannot ride along into the runner subprocess's argv.
+
+        Args:
+            value: The raw engine identifier from the request body.
+
+        Returns:
+            The stripped engine identifier.
+
+        Raises:
+            ValueError: If the value is blank/whitespace-only after
+                stripping, or contains a non-printable character.
+        """
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must not be empty or whitespace-only")
+        if _has_non_printable(stripped):
+            raise ValueError("must not contain non-printable characters")
+        return stripped
+
+    @field_validator("time_control")
+    @classmethod
+    def _validate_time_control(cls, value: str) -> str:
+        """Ensure the time control string is parseable.
+
+        Delegates to :func:`shared.time_control.parse_time_control` so
+        an unparseable string fails validation here (422) instead of
+        surfacing deep inside :meth:`SPRTService.start_test` as a 500.
+        The string is stripped first (matching ``engine_a``/``engine_b``)
+        and checked for non-printable characters before being handed to
+        the parser, since a bare parser failure can otherwise surface an
+        internal Python error message (e.g. from the parser's own
+        ``dict()`` construction) instead of a descriptive one.
+
+        Args:
+            value: The raw time control string from the request body.
+
+        Returns:
+            The stripped time control string.
+
+        Raises:
+            ValueError: If the value is blank/whitespace-only after
+                stripping, contains a non-printable character, or is not
+                a recognised time control format.
+        """
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("time_control must not be empty or whitespace-only")
+        if _has_non_printable(stripped):
+            raise ValueError("time_control must not contain non-printable characters")
+        try:
+            parse_time_control(stripped)
+        except ValueError as e:
+            raise ValueError(
+                f"invalid time_control {stripped!r}: expected one of "
+                "'movetime=<ms>', 'depth=<n>', 'nodes=<n>', or "
+                "'wtime=<ms>,btime=<ms>[,winc=<ms>,binc=<ms>]'"
+            ) from e
+        return stripped
+
+    @model_validator(mode="after")
+    def _validate_elo_bounds(self) -> Self:
+        """Ensure elo0 is strictly less than elo1.
+
+        ``elo0 >= elo1`` describes a statistically meaningless SPRT
+        (the null and alternative hypotheses don't bracket a positive
+        Elo gain), so it is rejected here rather than accepted and
+        handed to the runner.
+
+        Returns:
+            ``self``, unchanged.
+
+        Raises:
+            ValueError: If ``elo0 >= elo1``.
+        """
+        if self.elo0 >= self.elo1:
+            raise ValueError(f"elo0 ({self.elo0}) must be strictly less than elo1 ({self.elo1})")
+        return self
 
 
 class SPRTTestResponse(BaseModel):

--- a/backend/src/backend/routes/engines.py
+++ b/backend/src/backend/routes/engines.py
@@ -5,11 +5,15 @@ Returns the engine registry loaded from ``engines.json``.
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, HTTPException
 from shared.engine_registry import EngineRegistryError, load_registry
 from shared.utils import get_repo_root
 
 from backend.models import EngineResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/engines", tags=["engines"])
 
@@ -20,6 +24,9 @@ def list_engines() -> list[EngineResponse]:
     try:
         entries = load_registry(get_repo_root() / "engines.json")
     except EngineRegistryError as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        # EngineRegistryError embeds the registry's absolute path, so the
+        # message is logged server-side rather than returned to the client.
+        logger.exception("Failed to load the engine registry")
+        raise HTTPException(status_code=500, detail="Failed to load the engine registry") from e
 
     return [EngineResponse(id=e.id, name=e.name) for e in entries]

--- a/backend/src/backend/routes/sprt.py
+++ b/backend/src/backend/routes/sprt.py
@@ -6,11 +6,15 @@ subprocesses managed by :class:`backend.services.sprt_service.SPRTService`.
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, HTTPException, Request
 from shared.storage.repository import OpeningBookRepository
 
 from backend.converters import sprt_test_to_response
 from backend.models import SPRTTestCreatedResponse, SPRTTestCreateRequest, SPRTTestResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/sprt/tests", tags=["sprt"])
 
@@ -52,7 +56,11 @@ async def create_sprt_test(
             concurrency=body.concurrency,
         )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        # Launch failures surface as OSError whose message embeds the runner
+        # interpreter's absolute path, so the detail is logged server-side
+        # rather than returned to the client.
+        logger.exception("Failed to start the SPRT test")
+        raise HTTPException(status_code=500, detail="Failed to start the SPRT test") from e
 
     return SPRTTestCreatedResponse(id=test_id, status="running")
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -2,10 +2,45 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
+from typing import Any
 
-from backend.main import create_app
+from backend.main import (
+    _json_safe,  # type: ignore[reportPrivateUsage]
+    create_app,
+)
 from fastapi.testclient import TestClient
+
+
+class TestJsonSafe:
+    """Tests for `_json_safe`, the non-finite-float guard for 422 bodies."""
+
+    def test_leaves_finite_values_unchanged(self) -> None:
+        assert _json_safe({"a": 1, "b": [1.5, "x", None, True]}) == {
+            "a": 1,
+            "b": [1.5, "x", None, True],
+        }
+
+    def test_stringifies_non_finite_floats_anywhere_in_the_tree(self) -> None:
+        value: dict[str, Any] = {
+            "nan": float("nan"),
+            "inf": float("inf"),
+            "neg_inf": float("-inf"),
+            "nested": {"list": [float("nan"), 1.0, {"deep": float("inf")}]},
+        }
+        result = _json_safe(value)
+        assert result["nan"] == "nan"
+        assert result["inf"] == "inf"
+        assert result["neg_inf"] == "-inf"
+        assert result["nested"]["list"][0] == "nan"
+        assert result["nested"]["list"][1] == 1.0
+        assert result["nested"]["list"][2]["deep"] == "inf"
+        # Non-finite floats are gone; everything else is untouched.
+        assert not any(
+            isinstance(v, float) and not math.isfinite(v)
+            for v in [result["nan"], result["inf"], result["neg_inf"]]
+        )
 
 
 class TestCreateApp:
@@ -36,3 +71,20 @@ class TestCreateApp:
         client = TestClient(create_app(data_dir=tmp_path), raise_server_exceptions=False)
         resp = client.get("/api/games")
         assert resp.status_code == 200
+
+    def test_validation_error_on_unrelated_route_keeps_default_shape(self, tmp_path: Path) -> None:
+        """The app-wide `_validation_exception_handler` (added for SPRT's
+        NaN/Infinity guard) must not change FastAPI's default 422 body
+        shape for routes that have nothing to do with SPRT.
+        """
+        client = TestClient(create_app(data_dir=tmp_path), raise_server_exceptions=False)
+        # POST /api/openings/books requires a `file` field; omitting it
+        # triggers FastAPI's own request validation, independent of any
+        # SPRT-specific model.
+        resp = client.post("/api/openings/books")
+        assert resp.status_code == 422
+        body = resp.json()
+        errors = body["detail"]
+        assert errors
+        for error in errors:
+            assert set(error.keys()) >= {"type", "loc", "msg", "input"}

--- a/backend/tests/test_routes_engines.py
+++ b/backend/tests/test_routes_engines.py
@@ -65,6 +65,27 @@ class TestEnginesRoute:
             resp = client.get("/api/engines")
             assert resp.status_code == 500
 
+    def test_registry_error_does_not_leak_filesystem_path(self, client: TestClient) -> None:
+        """A registry failure must not echo the registry's absolute path (#162).
+
+        ``EngineRegistryError`` formats the registry path into its message
+        (e.g. ``Cannot read registry file '/abs/path/engines.json'``), so
+        returning ``str(e)`` as the error detail would leak it.
+        """
+        leaked_path = "/Users/someone/repos/chess-vibe/engines.json"
+        with patch(
+            "backend.routes.engines.load_registry",
+            side_effect=EngineRegistryError(f"Cannot read registry file '{leaked_path}': boom"),
+        ):
+            resp = client.get("/api/engines")
+
+        assert resp.status_code == 500
+        detail: str = resp.json()["detail"]
+        assert detail == "Failed to load the engine registry"
+        assert leaked_path not in detail
+        # No filesystem path can be present at all if there is no separator.
+        assert "/" not in detail
+
     def test_list_engines_uses_repo_root_for_registry(
         self, client: TestClient, tmp_path: Path
     ) -> None:

--- a/backend/tests/test_routes_sprt.py
+++ b/backend/tests/test_routes_sprt.py
@@ -153,6 +153,35 @@ class TestSPRTRoutes:
             call_kwargs = mock_start.call_args
             assert call_kwargs.kwargs["book_path"] == str(book_file)
 
+    def test_start_failure_does_not_leak_filesystem_path(self, client: TestClient) -> None:
+        """A runner launch failure must not echo the interpreter path (#162).
+
+        ``create_subprocess_exec`` raises ``OSError`` whose message embeds
+        the runner interpreter's absolute path; returning ``str(e)`` as the
+        error detail would leak it to the frontend.
+        """
+        leaked_path = "/Users/someone/repos/chess-vibe/sprt-runner/.venv/bin/python"
+        with patch(
+            "backend.services.sprt_service.SPRTService.start_test",
+            new_callable=AsyncMock,
+            side_effect=OSError(f"[Errno 2] No such file or directory: '{leaked_path}'"),
+        ):
+            resp = client.post(
+                "/api/sprt/tests",
+                json={
+                    "engine_a": "engine-a",
+                    "engine_b": "engine-b",
+                    "time_control": "movetime=100",
+                },
+            )
+
+        assert resp.status_code == 500
+        detail: str = resp.json()["detail"]
+        assert detail == "Failed to start the SPRT test"
+        assert leaked_path not in detail
+        # No filesystem path can be present at all if there is no separator.
+        assert "/" not in detail
+
 
 def _valid_payload(**overrides: Any) -> dict[str, Any]:
     """Build a valid POST /sprt/tests body, overridden field by field."""

--- a/backend/tests/test_routes_sprt.py
+++ b/backend/tests/test_routes_sprt.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from backend.main import create_app
 from fastapi.testclient import TestClient
@@ -148,3 +152,312 @@ class TestSPRTRoutes:
             mock_start.assert_called_once()
             call_kwargs = mock_start.call_args
             assert call_kwargs.kwargs["book_path"] == str(book_file)
+
+
+def _valid_payload(**overrides: Any) -> dict[str, Any]:
+    """Build a valid POST /sprt/tests body, overridden field by field."""
+    payload: dict[str, Any] = {
+        "engine_a": "engine-a",
+        "engine_b": "engine-b",
+        "time_control": "movetime=1000",
+        "elo0": 0.0,
+        "elo1": 5.0,
+        "alpha": 0.05,
+        "beta": 0.05,
+        "concurrency": 1,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _assert_422_mentions(response: httpx.Response, *expected_substrings: str) -> None:
+    """Assert a 422 response body's error details mention every given substring.
+
+    Checks the ``loc`` and ``msg`` of every error entry so both
+    field-scoped errors (e.g. ``alpha``) and whole-model errors (e.g.
+    the ``elo0 < elo1`` check) can be asserted the same way.
+    """
+    assert response.status_code == 422, response.text
+    body: dict[str, Any] = response.json()
+    errors: list[dict[str, Any]] = body["detail"]
+    assert errors, body
+    haystack = " ".join(
+        f"{' '.join(str(p) for p in e.get('loc', []))} {e.get('msg', '')}" for e in errors
+    )
+    for substring in expected_substrings:
+        assert substring in haystack, f"expected {substring!r} in error details: {errors}"
+
+
+class TestSPRTTestCreateRequestValidation:
+    """Validation rules for POST /sprt/tests request bodies (issue #163)."""
+
+    @pytest.fixture
+    def data_dir(self, tmp_path: Path) -> Path:
+        return tmp_path
+
+    @pytest.fixture
+    def client(self, data_dir: Path) -> TestClient:
+        return TestClient(create_app(data_dir=data_dir), raise_server_exceptions=False)
+
+    def _post(
+        self,
+        client: TestClient,
+        payload: Mapping[str, Any] | None = None,
+        body: bytes | None = None,
+    ) -> tuple[httpx.Response, AsyncMock]:
+        """POST to /api/sprt/tests with SPRTService.start_test mocked out.
+
+        Either a JSON-serialisable ``payload`` or raw ``body`` bytes
+        (for values like NaN that the standard JSON encoder rejects)
+        may be supplied. Returns both the HTTP response and the mock,
+        so callers can assert what (if anything) was forwarded to the
+        service — e.g. that a rejected payload never reaches it, or
+        that an accepted one is forwarded correctly normalised.
+        """
+        with patch(
+            "backend.services.sprt_service.SPRTService.start_test",
+            new_callable=AsyncMock,
+            return_value="test-123",
+        ) as mock_start:
+            if body is not None:
+                response = client.post(
+                    "/api/sprt/tests",
+                    content=body,
+                    headers={"content-type": "application/json"},
+                )
+            else:
+                response = client.post("/api/sprt/tests", json=payload)
+            return response, mock_start
+
+    # -- valid request still works -----------------------------------
+
+    def test_valid_request_returns_201(self, client: TestClient) -> None:
+        resp, mock_start = self._post(client, _valid_payload())
+        assert resp.status_code == 201, resp.text
+        assert resp.json() == {"id": "test-123", "status": "running"}
+        mock_start.assert_called_once()
+        kwargs = mock_start.call_args.kwargs
+        assert kwargs["engine_a"] == "engine-a"
+        assert kwargs["engine_b"] == "engine-b"
+        assert kwargs["time_control_str"] == "movetime=1000"
+        assert kwargs["concurrency"] == 1
+
+    # -- elo0 < elo1 ----------------------------------------------------
+
+    def test_elo0_equal_elo1_rejected(self, client: TestClient) -> None:
+        resp, mock_start = self._post(client, _valid_payload(elo0=5.0, elo1=5.0))
+        _assert_422_mentions(resp, "elo0", "elo1")
+        mock_start.assert_not_called()
+
+    def test_elo0_greater_than_elo1_rejected(self, client: TestClient) -> None:
+        resp, mock_start = self._post(client, _valid_payload(elo0=10.0, elo1=5.0))
+        _assert_422_mentions(resp, "elo0", "elo1")
+        mock_start.assert_not_called()
+
+    def test_elo0_less_than_elo1_accepted(self, client: TestClient) -> None:
+        resp, mock_start = self._post(client, _valid_payload(elo0=0.0, elo1=5.0))
+        assert resp.status_code == 201, resp.text
+        mock_start.assert_called_once()
+
+    # -- elo0 / elo1 magnitude bounds ---------------------------------
+
+    @pytest.mark.parametrize(
+        "elo0,elo1",
+        [(-1000.1, 0.0), (0.0, 1000.1), (-1e308, 5.0)],
+    )
+    def test_elo_beyond_magnitude_bound_rejected(
+        self, client: TestClient, elo0: float, elo1: float
+    ) -> None:
+        resp, mock_start = self._post(client, _valid_payload(elo0=elo0, elo1=elo1))
+        assert resp.status_code == 422, resp.text
+        mock_start.assert_not_called()
+
+    def test_elo_at_magnitude_bound_accepted(self, client: TestClient) -> None:
+        resp, mock_start = self._post(client, _valid_payload(elo0=-1000.0, elo1=1000.0))
+        assert resp.status_code == 201, resp.text
+        mock_start.assert_called_once()
+
+    # -- alpha / beta bounds ---------------------------------------------
+
+    @pytest.mark.parametrize("field", ["alpha", "beta"])
+    @pytest.mark.parametrize("value", [0.0, 1.0, -0.1, 1.1, -1, 5])
+    def test_alpha_beta_out_of_range_rejected(
+        self, client: TestClient, field: str, value: float
+    ) -> None:
+        resp, mock_start = self._post(client, _valid_payload(**{field: value}))
+        _assert_422_mentions(resp, field)
+        mock_start.assert_not_called()
+
+    @pytest.mark.parametrize("field", ["alpha", "beta"])
+    @pytest.mark.parametrize("value", [0.01, 0.05, 0.5, 0.99])
+    def test_alpha_beta_in_range_accepted(
+        self, client: TestClient, field: str, value: float
+    ) -> None:
+        resp, mock_start = self._post(client, _valid_payload(**{field: value}))
+        assert resp.status_code == 201, resp.text
+        mock_start.assert_called_once()
+
+    # -- concurrency bounds ------------------------------------------------
+
+    @pytest.mark.parametrize("value", [0, -1, 65])
+    def test_concurrency_out_of_range_rejected(self, client: TestClient, value: int) -> None:
+        resp, mock_start = self._post(client, _valid_payload(concurrency=value))
+        _assert_422_mentions(resp, "concurrency")
+        mock_start.assert_not_called()
+
+    @pytest.mark.parametrize("value", [1, 64])
+    def test_concurrency_bounds_accepted(self, client: TestClient, value: int) -> None:
+        resp, mock_start = self._post(client, _valid_payload(concurrency=value))
+        assert resp.status_code == 201, resp.text
+        assert mock_start.call_args.kwargs["concurrency"] == value
+
+    # -- engine_a / engine_b non-empty ------------------------------------
+
+    @pytest.mark.parametrize("field", ["engine_a", "engine_b"])
+    @pytest.mark.parametrize("value", ["", "   ", "\t\n", "\xa0"])
+    def test_empty_or_whitespace_engine_id_rejected(
+        self, client: TestClient, field: str, value: str
+    ) -> None:
+        resp, mock_start = self._post(client, _valid_payload(**{field: value}))
+        _assert_422_mentions(resp, field)
+        mock_start.assert_not_called()
+
+    def test_engine_ids_are_stripped_before_forwarding(self, client: TestClient) -> None:
+        resp, mock_start = self._post(
+            client, _valid_payload(engine_a="  engine-a  ", engine_b="engine-b\t")
+        )
+        assert resp.status_code == 201, resp.text
+        kwargs = mock_start.call_args.kwargs
+        assert kwargs["engine_a"] == "engine-a"
+        assert kwargs["engine_b"] == "engine-b"
+
+    # -- engine_a / engine_b length bound ----------------------------------
+
+    @pytest.mark.parametrize("field", ["engine_a", "engine_b"])
+    def test_engine_id_too_long_rejected(self, client: TestClient, field: str) -> None:
+        resp, mock_start = self._post(client, _valid_payload(**{field: "e" * 257}))
+        assert resp.status_code == 422, resp.text
+        errors = resp.json()["detail"]
+        assert any(e["type"] == "string_too_long" for e in errors), errors
+        mock_start.assert_not_called()
+
+    def test_engine_id_at_max_length_accepted(self, client: TestClient) -> None:
+        resp, mock_start = self._post(client, _valid_payload(engine_a="e" * 256))
+        assert resp.status_code == 201, resp.text
+        mock_start.assert_called_once()
+
+    # -- engine_a / engine_b non-printable characters ----------------------
+
+    @pytest.mark.parametrize("field", ["engine_a", "engine_b"])
+    @pytest.mark.parametrize(
+        "value",
+        ["eng\x00ine", "eng\nine", "eng\tine", "eng​ine"],
+        ids=["nul", "newline", "tab", "zero-width-space"],
+    )
+    def test_non_printable_char_in_engine_id_rejected(
+        self, client: TestClient, field: str, value: str
+    ) -> None:
+        resp, mock_start = self._post(client, _valid_payload(**{field: value}))
+        _assert_422_mentions(resp, field, "non-printable")
+        mock_start.assert_not_called()
+
+    # -- time_control ------------------------------------------------------
+
+    @pytest.mark.parametrize("value", ["", "   ", "\t\n"])
+    def test_blank_time_control_rejected_with_422(self, client: TestClient, value: str) -> None:
+        resp, mock_start = self._post(client, _valid_payload(time_control=value))
+        _assert_422_mentions(resp, "time_control")
+        mock_start.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "garbage",
+            "movetime=abc",
+            "movetime=0",
+            "movetime=-5",
+            # No '=' at all: shared.time_control.parse_time_control builds a
+            # dict via `dict(part.split("=", 1) for part in ...)`, which
+            # raises its own internal "dictionary update sequence element
+            # #0 has length 1; 2 is required" ValueError for these before
+            # ever reaching its "Unknown time control format" branch. The
+            # 422 message must not leak that internal text (issue #163
+            # review finding 1) — it must describe the supported formats.
+            "60+1",
+            "10+0.1",
+            "1000",
+        ],
+    )
+    def test_unparseable_time_control_rejected_with_descriptive_422(
+        self, client: TestClient, value: str
+    ) -> None:
+        resp, mock_start = self._post(client, _valid_payload(time_control=value))
+        _assert_422_mentions(resp, "time_control", "movetime")
+        assert "dictionary update sequence" not in resp.text
+        mock_start.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "movetime=1000",
+            "depth=10",
+            "nodes=50000",
+            "wtime=60000,btime=60000,winc=1000,binc=1000",
+        ],
+    )
+    def test_valid_time_control_forms_accepted(self, client: TestClient, value: str) -> None:
+        resp, mock_start = self._post(client, _valid_payload(time_control=value))
+        assert resp.status_code == 201, resp.text
+        mock_start.assert_called_once()
+
+    @pytest.mark.parametrize("value", [" movetime=1000", "movetime=1000 ", " movetime=1000 "])
+    def test_time_control_whitespace_is_stripped_before_forwarding(
+        self, client: TestClient, value: str
+    ) -> None:
+        resp, mock_start = self._post(client, _valid_payload(time_control=value))
+        assert resp.status_code == 201, resp.text
+        assert mock_start.call_args.kwargs["time_control_str"] == "movetime=1000"
+
+    def test_time_control_too_long_rejected(self, client: TestClient) -> None:
+        resp, mock_start = self._post(
+            client, _valid_payload(time_control="movetime=1000," + "x" * 128)
+        )
+        assert resp.status_code == 422, resp.text
+        errors = resp.json()["detail"]
+        assert any(e["type"] == "string_too_long" for e in errors), errors
+        mock_start.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "value", ["movetime=1000\x00", "movetime=1​000"], ids=["nul", "zero-width-space"]
+    )
+    def test_non_printable_char_in_time_control_rejected(
+        self, client: TestClient, value: str
+    ) -> None:
+        resp, mock_start = self._post(client, _valid_payload(time_control=value))
+        _assert_422_mentions(resp, "time_control", "non-printable")
+        mock_start.assert_not_called()
+
+    # -- NaN / Infinity guard on float fields -----------------------------
+
+    @pytest.mark.parametrize("field", ["elo0", "elo1", "alpha", "beta"])
+    @pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+    def test_non_finite_float_rejected(self, client: TestClient, field: str, token: str) -> None:
+        # json.dumps(..., allow_nan=False) (httpx's default) refuses to emit
+        # NaN/Infinity, so the body is built by hand with the bare token —
+        # matching how a non-finite literal would actually arrive on the wire.
+        body_dict = _valid_payload()
+        del body_dict[field]
+        rest = json.dumps(body_dict)[1:-1]
+        raw = ("{" + rest + (", " if rest else "") + f'"{field}": {token}' + "}").encode()
+        resp, mock_start = self._post(client, body=raw)
+        _assert_422_mentions(resp, field)
+        # Pin the rejection *reason*, not just the field name: dropping
+        # `allow_inf_nan=False` would make some of these fail for the
+        # wrong reason instead (e.g. via `lt=1`/`gt=0` on alpha/beta, or
+        # via the elo0<elo1 model validator) and still pass a field-name-
+        # only assertion.
+        errors = resp.json()["detail"]
+        matching = [e for e in errors if field in " ".join(str(p) for p in e.get("loc", []))]
+        assert matching, errors
+        assert any(e["type"] == "finite_number" for e in matching), matching
+        mock_start.assert_not_called()


### PR DESCRIPTION
Closes #163
Closes #164

`POST /api/sprt/tests` accepted essentially anything. Invalid input either started a statistically meaningless test or surfaced as a **500 from deep inside `SPRTService.start_test`** rather than a 422 at the boundary. While verifying the fix I also found a live filesystem-path leak that #162 was meant to close, so it is fixed here too — that was the last thing keeping umbrella #164 open.

## Validation (#163)

`SPRTTestCreateRequest` now rejects bad input at the edge:

| Rule | Constraint |
|---|---|
| `elo0 < elo1` | `model_validator(mode="after")` — an inverted bracket is a meaningless SPRT |
| `alpha`, `beta` | `gt=0, lt=1` exclusive |
| `concurrency` | `ge=1, le=64` |
| `engine_a`, `engine_b` | stripped, non-blank, `max_length=256`, no non-printable characters |
| `time_control` | stripped, non-blank, `max_length=128`, parsed via `shared.time_control.parse_time_control` |
| `elo0`, `elo1` | `allow_inf_nan=False`, bounded to ±1000 |

Wire format is unchanged — same field names (`book_id` preserved), same types, same defaults. Only the set of accepted *values* narrows, so the frontend needs no change.

### Three problems the issue didn't anticipate

- **NaN defeated the ordering check.** `elo0 >= elo1` is `False` when `elo0` is NaN, so a NaN passed straight through. Adding `allow_inf_nan=False` then produced a *500 instead of a 422*: Starlette renders JSON with `allow_nan=False`, so echoing the rejected NaN back in the error body crashed the response itself. A validation-error handler in `main.py` now stringifies non-finite floats, preserving FastAPI's default 422 body shape everywhere else (pinned by a test on an unrelated route).
- **Unbounded Elo hung a test.** Values past ~±123281 raise `OverflowError` in the runner's logistic Elo model, leaving the test pinned at `status=running` forever. Hence the ±1000 cap — far beyond any realistic SPRT bound.
- **Oversized and NUL-containing engine ids reached `argv`** and came back as 500s, which is the exact failure mode acceptance criterion 5 set out to eliminate.

Deliberately **not** added, as scope creep: a joint `alpha + beta < 1` constraint (it would reject the `alpha=0.99` case the acceptance criteria require to stay valid) and a Unicode-confusables table.

## Path leak (#162, reopened in practice)

#169 removed filesystem paths from response *models* but left them in error *bodies*. Two routes returned raw exception text as the HTTP detail, so even a **valid** request could leak an absolute path:

```json
{"detail": "[Errno 2] No such file or directory: '/Users/.../sprt-runner/.venv/bin/python'"}
```

- `routes/sprt.py` — runner launch failure; `OSError` embeds the interpreter path
- `routes/engines.py` — `EngineRegistryError` formats the registry's absolute path into its message whenever `engines.json` is unreadable or invalid JSON

Both now `logger.exception` server-side and return a generic detail, restoring the hard rule that API responses never expose filesystem paths or shell commands. The WebSocket handlers were audited too and are already clean — the messages they forward (`Illegal move: ...`, `Engine 'x' not found in registry`) carry no paths, and the outer handler only logs.

## Verification

```
184 passed, 2 deselected   (94 on main)
pyright strict: 0 errors   ruff check: passed   ruff format: 90 files clean
```

Both leak tests were mutation-checked: reverting only the two source fixes makes them fail with the leaked path visible, so they genuinely pin the behaviour. The validation rules were also probed live against a running app — oversized ids, NUL bytes, a literal `NaN` token in the raw body, zero-width spaces and BOM all return 422.

Backend-only; `shared/`, `sprt-runner/`, `frontend/`, and `engines/` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)