### PR TITLE
refactor: open the Syzygy tablebase once per game instead of per probe

### DIFF
--- a/sprt-runner/src/sprt_runner/adjudication.py
+++ b/sprt-runner/src/sprt_runner/adjudication.py
@@ -70,6 +70,7 @@ def check_adjudication(
     *,
     move_number: int,
     config: AdjudicationConfig,
+    tablebase: chess.syzygy.Tablebase | None,
     board: chess.Board | None = None,
 ) -> AdjudicationResult | None:
     """Check whether a game should be adjudicated.
@@ -83,13 +84,25 @@ def check_adjudication(
         move_number: Current move number in the game.
         config: Adjudication thresholds.
         board: Current board position for tablebase probing (optional).
+        tablebase: An already-open Syzygy tablebase handle, or ``None`` to
+            skip tablebase adjudication (e.g. ``syzygy_path`` is unset, or
+            opening the tablebase failed — that failure is already logged
+            once by the opener). This parameter has no default: a caller
+            that sets ``config.syzygy_path`` but forgets to open and pass
+            the handle fails at type-check time (pyright strict) instead
+            of silently losing tablebase adjudication at runtime. The
+            caller (see ``game.py``) owns opening and closing the handle
+            once per game; this function only probes it.
 
     Returns:
         An AdjudicationResult if the game should be adjudicated, else None.
     """
-    # Syzygy tablebase adjudication (highest priority)
-    if board is not None and config.syzygy_path is not None:
-        tb_result = _check_syzygy(board, config.syzygy_path)
+    # Syzygy tablebase adjudication (highest priority). ``tablebase is
+    # None`` covers both "disabled" and "failed to open" — both are
+    # already surfaced (or are simply not configured) upstream, so no
+    # additional warning is logged here on every position.
+    if board is not None and config.syzygy_path is not None and tablebase is not None:
+        tb_result = _check_syzygy(board, tablebase)
         if tb_result is not None:
             return tb_result
 
@@ -184,17 +197,18 @@ def _check_draw(
 
 def _check_syzygy(
     board: chess.Board,
-    syzygy_path: Path,
+    tablebase: chess.syzygy.Tablebase,
 ) -> AdjudicationResult | None:
     """Check for Syzygy tablebase adjudication.
 
-    Probes the Syzygy tablebases to determine if the position has a
+    Probes the given tablebase handle to determine if the position has a
     known outcome. Only probes when the number of pieces on the board
     is within tablebase range.
 
     Args:
         board: Current board position.
-        syzygy_path: Path to the Syzygy tablebase directory.
+        tablebase: An already-open Syzygy tablebase handle. The caller
+            owns its lifetime (opened once per game, closed when done).
 
     Returns:
         An AdjudicationResult if the position is resolved, else None.
@@ -204,11 +218,8 @@ def _check_syzygy(
     if piece_count > 7:
         return None
 
-    # Note: opening tablebase per probe is acceptable since this only
-    # runs when pieces ≤ 7 (late endgame). python-chess caches internally.
     try:
-        with chess.syzygy.open_tablebase(str(syzygy_path)) as tablebase:
-            wdl = tablebase.probe_wdl(board)
+        wdl = tablebase.probe_wdl(board)
     except KeyError:
         # Position not in tablebases
         return None

--- a/sprt-runner/src/sprt_runner/game.py
+++ b/sprt-runner/src/sprt_runner/game.py
@@ -13,8 +13,10 @@ import logging
 import time
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 
 import chess
+import chess.syzygy
 from shared.storage.models import GameResult, Move
 from shared.time_control import (
     FixedTimeControl,
@@ -158,6 +160,31 @@ def _extract_move_data(infos: list[UCIInfo]) -> _MoveData:
     return data
 
 
+def _open_tablebase(syzygy_path: Path | None) -> chess.syzygy.Tablebase | None:
+    """Open the Syzygy tablebase handle once, for reuse across a whole game.
+
+    Args:
+        syzygy_path: Path to the Syzygy tablebase directory, or None to
+            disable tablebase adjudication.
+
+    Returns:
+        An open Tablebase handle, or None if disabled or the tablebase
+        could not be opened (e.g. missing or unreadable directory —
+        logged, not fatal, so a bad path doesn't kill the game).
+    """
+    if syzygy_path is None:
+        return None
+    try:
+        return chess.syzygy.open_tablebase(str(syzygy_path))
+    except OSError:
+        logger.warning(
+            "Failed to open Syzygy tablebase at %s; tablebase adjudication disabled for this game",
+            syzygy_path,
+            exc_info=True,
+        )
+        return None
+
+
 async def play_game(
     *,
     white: UCIClient,
@@ -166,10 +193,47 @@ async def play_game(
 ) -> GameOutcome:
     """Play a complete game between two UCI engines.
 
+    Opens the Syzygy tablebase handle (if configured) once for the whole
+    game and guarantees it is closed on every exit path, including
+    exceptions, before delegating to the game loop.
+
     Args:
         white: UCI client for the white engine.
         black: UCI client for the black engine.
         config: Game configuration.
+
+    Returns:
+        GameOutcome with the result, termination reason, and moves.
+    """
+    tablebase = _open_tablebase(config.adjudication.syzygy_path)
+    try:
+        return await _play_game(white=white, black=black, config=config, tablebase=tablebase)
+    finally:
+        if tablebase is not None:
+            try:
+                tablebase.close()
+            except Exception:
+                # A close failure must not destroy an already-completed
+                # GameOutcome (or mask an exception already propagating
+                # through this finally block) — log and move on.
+                logger.warning("Failed to close Syzygy tablebase", exc_info=True)
+
+
+async def _play_game(
+    *,
+    white: UCIClient,
+    black: UCIClient,
+    config: GameConfig,
+    tablebase: chess.syzygy.Tablebase | None,
+) -> GameOutcome:
+    """Run the game loop for a single game between two UCI engines.
+
+    Args:
+        white: UCI client for the white engine.
+        black: UCI client for the black engine.
+        config: Game configuration.
+        tablebase: An already-open Syzygy tablebase handle, or None.
+            Owned and closed by ``play_game``; this function only probes it.
 
     Returns:
         GameOutcome with the result, termination reason, and moves.
@@ -336,6 +400,7 @@ async def play_game(
             move_number=full_moves,
             config=config.adjudication,
             board=board,
+            tablebase=tablebase,
         )
         if adj_result is not None:
             logger.info("Adjudication: %s", adj_result.reason)

--- a/sprt-runner/tests/test_adjudication.py
+++ b/sprt-runner/tests/test_adjudication.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import chess
+import pytest
 from sprt_runner.adjudication import (
     AdjudicationConfig,
     AdjudicationType,
@@ -45,7 +47,9 @@ class TestWinAdjudication:
         # Only 2 moves above threshold
         white_scores = [1100, 1200]
         black_scores = [-1100, -1200]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is None
 
     def test_win_adjudication_white_wins(self) -> None:
@@ -53,7 +57,9 @@ class TestWinAdjudication:
         config = AdjudicationConfig(win_threshold_cp=1000, win_consecutive_moves=3)
         white_scores = [1100, 1200, 1300]
         black_scores = [-1100, -1200, -1300]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is not None
         assert result.adjudication_type == AdjudicationType.WIN_WHITE
 
@@ -62,7 +68,9 @@ class TestWinAdjudication:
         config = AdjudicationConfig(win_threshold_cp=1000, win_consecutive_moves=3)
         white_scores = [-1100, -1200, -1300]
         black_scores = [1100, 1200, 1300]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is not None
         assert result.adjudication_type == AdjudicationType.WIN_BLACK
 
@@ -71,7 +79,9 @@ class TestWinAdjudication:
         config = AdjudicationConfig(win_threshold_cp=1000, win_consecutive_moves=3)
         white_scores = [1100, 1200, 1300]
         black_scores = [100, 200, 300]  # Black thinks it's winning too
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is None
 
     def test_win_resets_on_below_threshold(self) -> None:
@@ -80,7 +90,9 @@ class TestWinAdjudication:
         # 2 above, 1 below, 2 above - not enough consecutive
         white_scores = [1100, 1200, 500, 1100, 1200]
         black_scores = [-1100, -1200, -500, -1100, -1200]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is None
 
 
@@ -92,7 +104,9 @@ class TestDrawAdjudication:
         config = AdjudicationConfig(draw_threshold_cp=10, draw_consecutive_moves=3, draw_min_move=5)
         white_scores = [5, -3, 8]
         black_scores = [-2, 7, -5]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is not None
         assert result.adjudication_type == AdjudicationType.DRAW
 
@@ -103,7 +117,9 @@ class TestDrawAdjudication:
         )
         white_scores = [5, -3, 8]
         black_scores = [-2, 7, -5]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is None
 
     def test_no_draw_eval_too_high(self) -> None:
@@ -111,7 +127,9 @@ class TestDrawAdjudication:
         config = AdjudicationConfig(draw_threshold_cp=10, draw_consecutive_moves=3, draw_min_move=5)
         white_scores = [5, -3, 50]
         black_scores = [-2, 7, -5]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is None
 
 
@@ -121,7 +139,7 @@ class TestAdjudicationDisabled:
     def test_no_adjudication_with_none_scores(self) -> None:
         """Empty score lists should not trigger adjudication."""
         config = AdjudicationConfig()
-        result = check_adjudication([], [], move_number=100, config=config)
+        result = check_adjudication([], [], move_number=100, config=config, tablebase=None)
         assert result is None
 
     def test_disabled_win_adjudication(self) -> None:
@@ -129,7 +147,9 @@ class TestAdjudicationDisabled:
         config = AdjudicationConfig(win_consecutive_moves=0)
         white_scores = [1100, 1200, 1300]
         black_scores = [-1100, -1200, -1300]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is None
 
     def test_disabled_draw_adjudication(self) -> None:
@@ -137,12 +157,20 @@ class TestAdjudicationDisabled:
         config = AdjudicationConfig(draw_consecutive_moves=0, draw_min_move=0)
         white_scores = [5, -3, 8]
         black_scores = [-2, 7, -5]
-        result = check_adjudication(white_scores, black_scores, move_number=10, config=config)
+        result = check_adjudication(
+            white_scores, black_scores, move_number=10, config=config, tablebase=None
+        )
         assert result is None
 
 
 class TestSyzygyAdjudication:
-    """Tests for Syzygy tablebase adjudication logic."""
+    """Tests for Syzygy tablebase adjudication logic.
+
+    The tablebase handle is opened once per game by the caller (see
+    ``game.py``) and passed in directly — ``check_adjudication`` never
+    opens tablebases itself, so these tests pass a mock handle rather
+    than patching ``chess.syzygy.open_tablebase``.
+    """
 
     def test_syzygy_white_wins(self, tmp_path: Path) -> None:
         """Tablebase probe shows white wins."""
@@ -153,11 +181,10 @@ class TestSyzygyAdjudication:
         board = chess.Board("8/8/8/8/8/8/1k6/KQ6 w - - 0 1")
         mock_tb = MagicMock()
         mock_tb.probe_wdl.return_value = 2  # Win
-        mock_tb.__enter__ = MagicMock(return_value=mock_tb)
-        mock_tb.__exit__ = MagicMock(return_value=False)
 
-        with patch("chess.syzygy.open_tablebase", return_value=mock_tb):
-            result = check_adjudication([], [], move_number=100, config=config, board=board)
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=mock_tb
+        )
 
         assert result is not None
         assert result.adjudication_type == AdjudicationType.WIN_WHITE
@@ -171,11 +198,10 @@ class TestSyzygyAdjudication:
         board = chess.Board("8/8/8/8/8/8/1K6/kq6 b - - 0 1")
         mock_tb = MagicMock()
         mock_tb.probe_wdl.return_value = 2  # Win for side to move (black)
-        mock_tb.__enter__ = MagicMock(return_value=mock_tb)
-        mock_tb.__exit__ = MagicMock(return_value=False)
 
-        with patch("chess.syzygy.open_tablebase", return_value=mock_tb):
-            result = check_adjudication([], [], move_number=100, config=config, board=board)
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=mock_tb
+        )
 
         assert result is not None
         assert result.adjudication_type == AdjudicationType.WIN_BLACK
@@ -188,11 +214,10 @@ class TestSyzygyAdjudication:
         board = chess.Board("8/8/8/8/8/8/1k6/K7 w - - 0 1")
         mock_tb = MagicMock()
         mock_tb.probe_wdl.return_value = 0  # Draw
-        mock_tb.__enter__ = MagicMock(return_value=mock_tb)
-        mock_tb.__exit__ = MagicMock(return_value=False)
 
-        with patch("chess.syzygy.open_tablebase", return_value=mock_tb):
-            result = check_adjudication([], [], move_number=100, config=config, board=board)
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=mock_tb
+        )
 
         assert result is not None
         assert result.adjudication_type == AdjudicationType.DRAW
@@ -204,8 +229,14 @@ class TestSyzygyAdjudication:
             syzygy_path=tmp_path, win_consecutive_moves=0, draw_consecutive_moves=0
         )
         board = chess.Board()  # Starting position has 32 pieces
-        result = check_adjudication([], [], move_number=100, config=config, board=board)
+        mock_tb = MagicMock()
+
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=mock_tb
+        )
+
         assert result is None
+        mock_tb.probe_wdl.assert_not_called()
 
     def test_syzygy_disabled_when_no_path(self) -> None:
         """No tablebase adjudication when syzygy_path is None."""
@@ -213,7 +244,9 @@ class TestSyzygyAdjudication:
             syzygy_path=None, win_consecutive_moves=0, draw_consecutive_moves=0
         )
         board = chess.Board("8/8/8/8/8/8/1k6/KQ6 w - - 0 1")
-        result = check_adjudication([], [], move_number=100, config=config, board=board)
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=None
+        )
         assert result is None
 
     def test_syzygy_key_error_returns_none(self, tmp_path: Path) -> None:
@@ -224,11 +257,10 @@ class TestSyzygyAdjudication:
         board = chess.Board("8/8/8/8/8/8/1k6/KQ6 w - - 0 1")
         mock_tb = MagicMock()
         mock_tb.probe_wdl.side_effect = KeyError("not found")
-        mock_tb.__enter__ = MagicMock(return_value=mock_tb)
-        mock_tb.__exit__ = MagicMock(return_value=False)
 
-        with patch("chess.syzygy.open_tablebase", return_value=mock_tb):
-            result = check_adjudication([], [], move_number=100, config=config, board=board)
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=mock_tb
+        )
 
         assert result is None
 
@@ -241,11 +273,56 @@ class TestSyzygyAdjudication:
         board = chess.Board("8/8/8/8/8/8/1k6/K7 w - - 0 1")
         mock_tb = MagicMock()
         mock_tb.probe_wdl.return_value = -2  # Loss for side to move
-        mock_tb.__enter__ = MagicMock(return_value=mock_tb)
-        mock_tb.__exit__ = MagicMock(return_value=False)
 
-        with patch("chess.syzygy.open_tablebase", return_value=mock_tb):
-            result = check_adjudication([], [], move_number=100, config=config, board=board)
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=mock_tb
+        )
 
         assert result is not None
         assert result.adjudication_type == AdjudicationType.WIN_BLACK
+
+    def test_syzygy_explicit_none_handle_disables_without_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``tablebase=None`` with ``syzygy_path`` set is a silent, deliberate disable.
+
+        ``tablebase`` has no default (see
+        ``test_tablebase_parameter_is_required`` below), so the only way
+        to reach this branch is to explicitly pass ``tablebase=None`` —
+        e.g. because opening the tablebase already failed and was logged
+        once, at the point of failure, by ``_open_tablebase`` in
+        ``game.py``. Re-warning here on every position would just be
+        per-move log spam (previously up to ~1000 duplicate warnings per
+        game); this test pins that it no longer happens.
+        """
+        config = AdjudicationConfig(
+            syzygy_path=tmp_path, win_consecutive_moves=0, draw_consecutive_moves=0
+        )
+        board = chess.Board("8/8/8/8/8/8/1k6/KQ6 w - - 0 1")
+
+        with caplog.at_level(logging.WARNING):
+            result = check_adjudication(
+                [], [], move_number=100, config=config, board=board, tablebase=None
+            )
+
+        assert result is None
+        assert caplog.records == []
+
+    def test_tablebase_parameter_is_required(self, tmp_path: Path) -> None:
+        """``tablebase`` has no default: omitting it fails immediately.
+
+        This is the static guard against the original "silent no-op"
+        hazard: a caller that sets ``config.syzygy_path`` but forgets to
+        open and pass the handle now fails at type-check time (pyright
+        strict flags a missing required argument) instead of silently
+        losing tablebase adjudication at runtime.
+        """
+        config = AdjudicationConfig(
+            syzygy_path=tmp_path, win_consecutive_moves=0, draw_consecutive_moves=0
+        )
+        board = chess.Board("8/8/8/8/8/8/1k6/KQ6 w - - 0 1")
+
+        with pytest.raises(TypeError, match="tablebase"):
+            check_adjudication(  # type: ignore[call-arg]
+                [], [], move_number=100, config=config, board=board
+            )

--- a/sprt-runner/tests/test_game.py
+++ b/sprt-runner/tests/test_game.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
+import logging
+import pickle
 from collections.abc import Sequence
-from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from shared.storage.models import GameResult
@@ -295,6 +299,340 @@ class TestPlayGame:
 
         assert outcome.result == GameResult.WHITE_WIN
         assert outcome.termination == TerminationReason.CHECKMATE
+
+
+class TestSyzygyTablebaseLifecycle:
+    """Tests that the Syzygy tablebase handle is opened once per game and reused."""
+
+    @pytest.mark.asyncio
+    async def test_tablebase_opened_once_not_per_probe(self) -> None:
+        """The tablebase handle is opened once and reused for every probe.
+
+        A bare K+P vs K endgame keeps the piece count low for the whole
+        game, so every half-move triggers an adjudication probe. Kings
+        shuffle back and forth (never adjacent, never giving check) so
+        every scripted move stays legal. The tablebase mock always raises
+        KeyError (position not found) so the game runs to the max-moves
+        limit, producing several probes.
+        """
+        fen = "4k3/8/8/8/8/8/P7/4K3 w - - 0 1"
+        white_moves = ["e1d1", "d1e1"]
+        black_moves = ["e8d8", "d8e8"]
+
+        white_engine = _mock_engine(white_moves)
+        black_engine = _mock_engine(black_moves)
+
+        mock_tb = MagicMock()
+        mock_tb.probe_wdl.side_effect = KeyError("not found")
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=1),
+            adjudication=AdjudicationConfig(
+                syzygy_path=Path("/fake/syzygy"),
+                win_consecutive_moves=0,
+                draw_consecutive_moves=0,
+            ),
+            start_fen=fen,
+            max_moves=2,
+        )
+
+        with patch("chess.syzygy.open_tablebase", return_value=mock_tb) as mock_open:
+            outcome = await play_game(white=white_engine, black=black_engine, config=config)
+
+        mock_open.assert_called_once()
+        assert mock_tb.probe_wdl.call_count == 4
+        # Exactly one close, after all probes — guards against a handle
+        # closed (and then reused) mid-game, e.g. inside _check_syzygy.
+        mock_tb.close.assert_called_once()
+        assert outcome.termination == TerminationReason.MAX_MOVES
+
+    @pytest.mark.asyncio
+    async def test_tablebase_closed_when_game_ends_normally(self) -> None:
+        """The tablebase handle is closed once the game completes."""
+        white_moves = ["e2e4", "d1h5", "f1c4", "h5f7"]
+        black_moves = ["e7e5", "b8c6", "g8f6"]
+
+        white_engine = _mock_engine(white_moves)
+        black_engine = _mock_engine(black_moves)
+
+        mock_tb = MagicMock()
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=5),
+            adjudication=AdjudicationConfig(
+                syzygy_path=Path("/fake/syzygy"),
+                win_consecutive_moves=0,
+                draw_consecutive_moves=0,
+            ),
+        )
+
+        with patch("chess.syzygy.open_tablebase", return_value=mock_tb):
+            outcome = await play_game(white=white_engine, black=black_engine, config=config)
+
+        assert outcome.termination == TerminationReason.CHECKMATE
+        mock_tb.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tablebase_closed_on_exception(self) -> None:
+        """The tablebase handle is closed even when the game loop raises."""
+        white_engine = _mock_engine(["h1h2"])
+        white_engine.position = AsyncMock(side_effect=RuntimeError("boom"))
+        black_engine = _mock_engine([])
+
+        mock_tb = MagicMock()
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=5),
+            adjudication=AdjudicationConfig(syzygy_path=Path("/fake/syzygy")),
+        )
+
+        with (
+            patch("chess.syzygy.open_tablebase", return_value=mock_tb),
+            pytest.raises(RuntimeError),
+        ):
+            await play_game(white=white_engine, black=black_engine, config=config)
+
+        mock_tb.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_completed_outcome_survives_close_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A tablebase.close() failure must not destroy a completed GameOutcome.
+
+        Closing the handle is best-effort cleanup after the game is
+        already decided; if it raises (e.g. the underlying mmap close
+        fails), the already-computed result must still be returned, not
+        replaced by the close exception.
+        """
+        white_moves = ["e2e4", "d1h5", "f1c4", "h5f7"]
+        black_moves = ["e7e5", "b8c6", "g8f6"]
+
+        white_engine = _mock_engine(white_moves)
+        black_engine = _mock_engine(black_moves)
+
+        mock_tb = MagicMock()
+        mock_tb.close.side_effect = OSError("mmap close failed")
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=5),
+            adjudication=AdjudicationConfig(
+                syzygy_path=Path("/fake/syzygy"),
+                win_consecutive_moves=0,
+                draw_consecutive_moves=0,
+            ),
+        )
+
+        with (
+            patch("chess.syzygy.open_tablebase", return_value=mock_tb),
+            caplog.at_level(logging.WARNING),
+        ):
+            outcome = await play_game(white=white_engine, black=black_engine, config=config)
+
+        assert outcome.result == GameResult.WHITE_WIN
+        assert outcome.termination == TerminationReason.CHECKMATE
+        mock_tb.close.assert_called_once()
+        assert any("close" in record.message.lower() for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_tablebase_opened_when_syzygy_path_is_none(self) -> None:
+        """No tablebase is opened at all when syzygy_path is None."""
+        white_moves = ["e2e4", "d1h5", "f1c4", "h5f7"]
+        black_moves = ["e7e5", "b8c6", "g8f6"]
+
+        white_engine = _mock_engine(white_moves)
+        black_engine = _mock_engine(black_moves)
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=5),
+            adjudication=AdjudicationConfig(
+                syzygy_path=None, win_consecutive_moves=0, draw_consecutive_moves=0
+            ),
+        )
+
+        with patch("chess.syzygy.open_tablebase") as mock_open:
+            outcome = await play_game(white=white_engine, black=black_engine, config=config)
+
+        mock_open.assert_not_called()
+        assert outcome.termination == TerminationReason.CHECKMATE
+
+    @pytest.mark.asyncio
+    async def test_tablebase_open_failure_does_not_crash_game(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Open failure is logged once, not per move, and does not crash the game.
+
+        Pins two things: (1) the failure is actually logged — deleting
+        the warning in ``_open_tablebase`` must turn this test red — and
+        (2) it is logged exactly once, not once per half-move for the
+        rest of the game (the fix for the original per-move warning
+        spam this test used to let through silently).
+        """
+        white_moves = ["e2e4", "d1h5", "f1c4", "h5f7"]
+        black_moves = ["e7e5", "b8c6", "g8f6"]
+
+        white_engine = _mock_engine(white_moves)
+        black_engine = _mock_engine(black_moves)
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=5),
+            adjudication=AdjudicationConfig(
+                syzygy_path=Path("/fake/syzygy"),
+                win_consecutive_moves=0,
+                draw_consecutive_moves=0,
+            ),
+        )
+
+        with (
+            patch("chess.syzygy.open_tablebase", side_effect=OSError("cannot open directory")),
+            caplog.at_level(logging.WARNING),
+        ):
+            outcome = await play_game(white=white_engine, black=black_engine, config=config)
+
+        assert outcome.result == GameResult.WHITE_WIN
+        assert outcome.termination == TerminationReason.CHECKMATE
+        open_failure_records = [r for r in caplog.records if "Failed to open Syzygy" in r.message]
+        assert len(open_failure_records) == 1
+        assert len(caplog.records) == 1
+
+    @pytest.mark.asyncio
+    async def test_tablebase_opened_and_closed_once_per_game_not_per_process(self) -> None:
+        """Each ``play_game`` call opens and closes its own handle.
+
+        Guards against the module-level-cache-keyed-by-path design the
+        issue explicitly rejected (global mutable state with no clear
+        ownership or close point): under a cache, a second game would
+        reuse — or worse, reuse an already-closed — handle from the
+        first, so ``open_tablebase`` would be called once total rather
+        than once per game.
+        """
+        white_moves = ["e2e4", "d1h5", "f1c4", "h5f7"]
+        black_moves = ["e7e5", "b8c6", "g8f6"]
+
+        mock_tb = MagicMock()
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=5),
+            adjudication=AdjudicationConfig(
+                syzygy_path=Path("/fake/syzygy"),
+                win_consecutive_moves=0,
+                draw_consecutive_moves=0,
+            ),
+        )
+
+        with patch("chess.syzygy.open_tablebase", return_value=mock_tb) as mock_open:
+            outcome_1 = await play_game(
+                white=_mock_engine(white_moves), black=_mock_engine(black_moves), config=config
+            )
+            outcome_2 = await play_game(
+                white=_mock_engine(white_moves), black=_mock_engine(black_moves), config=config
+            )
+
+        assert outcome_1.termination == TerminationReason.CHECKMATE
+        assert outcome_2.termination == TerminationReason.CHECKMATE
+        assert mock_open.call_count == 2
+        assert mock_tb.close.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_tablebase_closed_on_adjudication_exit(self) -> None:
+        """The handle is closed when the game ends via tablebase adjudication itself.
+
+        Every other lifecycle test exits via CHECKMATE, MAX_MOVES, or an
+        exception; this covers the one exit where a probe directly
+        produces the returned ``GameOutcome``.
+        """
+        fen = "4k3/8/8/8/8/8/P7/4K3 w - - 0 1"
+        white_engine = _mock_engine(["e1d1"])
+        black_engine = _mock_engine([])
+
+        mock_tb = MagicMock()
+        mock_tb.probe_wdl.return_value = 2  # Decisive for side to move
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=1),
+            adjudication=AdjudicationConfig(
+                syzygy_path=Path("/fake/syzygy"),
+                win_consecutive_moves=0,
+                draw_consecutive_moves=0,
+            ),
+            start_fen=fen,
+        )
+
+        with patch("chess.syzygy.open_tablebase", return_value=mock_tb):
+            outcome = await play_game(white=white_engine, black=black_engine, config=config)
+
+        assert outcome.termination == TerminationReason.ADJUDICATION
+        mock_tb.probe_wdl.assert_called_once()
+        mock_tb.close.assert_called_once()
+
+
+class TestGameConfigPicklability:
+    """Regression test: GameConfig must remain picklable across process boundaries.
+
+    The SPRT runner sends GameConfig (via WorkerTask) to worker processes
+    through multiprocessing.Process, which pickles its args. A live
+    Syzygy tablebase handle is not picklable, so it must never live on
+    the config — only the syzygy_path (a Path) does.
+    """
+
+    def test_game_config_with_syzygy_path_is_picklable(self) -> None:
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=5),
+            adjudication=AdjudicationConfig(syzygy_path=Path("/fake/syzygy")),
+        )
+
+        pickled = pickle.dumps(config)
+        restored = pickle.loads(pickled)
+
+        assert restored.adjudication.syzygy_path == Path("/fake/syzygy")
+
+    def test_adjudication_config_has_no_tablebase_field(self) -> None:
+        """Structural guard: AdjudicationConfig must never gain a Tablebase field.
+
+        A frozen-dataclass instance with a ``None``-valued field still
+        pickles fine, so an instance-level check alone would not catch a
+        future ``tablebase: chess.syzygy.Tablebase | None = None`` field
+        being added back to the config — exactly the design the issue
+        rejected. Assert on the declared shape instead of one instance.
+        """
+        for f in dataclasses.fields(AdjudicationConfig):
+            assert "Tablebase" not in str(f.type), (
+                f"AdjudicationConfig.{f.name} must not reference chess.syzygy.Tablebase; "
+                "the open handle belongs in play_game(), not the (pickled) config"
+            )
+
+    @pytest.mark.asyncio
+    async def test_config_stays_picklable_after_handle_is_opened(self) -> None:
+        """The config instance play_game() receives must stay picklable after use.
+
+        Uses an unpicklable stand-in for the tablebase handle (a bare
+        ``MagicMock`` fails ``pickle.dumps``), so this would fail if
+        ``play_game`` ever stashed the open handle onto ``config`` —
+        e.g. via ``dataclasses.replace`` — even though
+        ``test_game_config_with_syzygy_path_is_picklable`` above stays
+        green regardless (it never opens a handle at all).
+        """
+        white_moves = ["e2e4", "d1h5", "f1c4", "h5f7"]
+        black_moves = ["e7e5", "b8c6", "g8f6"]
+
+        config = GameConfig(
+            time_control=DepthTimeControl(depth=5),
+            adjudication=AdjudicationConfig(
+                syzygy_path=Path("/fake/syzygy"),
+                win_consecutive_moves=0,
+                draw_consecutive_moves=0,
+            ),
+        )
+
+        unpicklable_handle = MagicMock()
+        with patch("chess.syzygy.open_tablebase", return_value=unpicklable_handle):
+            await play_game(
+                white=_mock_engine(white_moves), black=_mock_engine(black_moves), config=config
+            )
+
+        pickled = pickle.dumps(config)
+        restored = pickle.loads(pickled)
+        assert restored.adjudication.syzygy_path == Path("/fake/syzygy")
 
 
 class TestWatchdogTimeoutMs:


### PR DESCRIPTION
Closes #134
Closes #122

`_check_syzygy` opened a fresh `chess.syzygy.Tablebase` on **every probe**, so a long low-piece-count endgame rescanned the tablebase directory and re-mmapped its files on every half-move. The handle is now opened once per game and reused.

This is the last open sub-issue of umbrella #122, so that epic closes too.

## The issue's suggested design would have broken production

#134 proposes storing the handle on `AdjudicationConfig`. That config travels inside `GameConfig` → `WorkerTask` and is **pickled** across the `multiprocessing.Process` boundary in `runner.py`, and a `Tablebase` is not picklable — every SPRT run would have died at worker spawn. Only `syzygy_path` (a `Path`) stays on the config; the handle is opened inside the worker process.

Two regression tests pin this: a structural check that no `AdjudicationConfig` field references `Tablebase`, and a `pickle.dumps` round-trip *after* `play_game` has run with a handle open. The second was verified by mutation — stashing a handle onto the config makes it fail with `PicklingError`.

The issue's other alternative, a module-level cache keyed by path, was rejected: process-global mutable state with no owner and no natural close point. Since `runner.py` spawns one process per game, per-game open is already the maximum reuse the architecture allows.

## Lifetime management

`play_game()` is now a thin wrapper owning open/close, delegating the otherwise-unchanged loop to `_play_game`. That gives `try/finally` close-on-all-paths — verified across all twelve exit paths (max-moves, checkmate, stalemate, draw-rule, adjudication, UCI timeout/error, watchdog timeout, illegal move, invalid UCI, arbitrary exception, and `CancelledError` from worker termination) — without re-indenting a dozen `return GameOutcome(...)` statements. Only the signature and the single `check_adjudication` call changed inside the loop.

## Two robustness bugs found while verifying

- **A `close()` failure could delete a game from the SPRT tally.** An exception from `tablebase.close()` in the `finally` replaced an already-computed `GameOutcome`, which the runner then dropped. Close is now best-effort and logged.
- **`check_adjudication` takes `tablebase` as a required keyword arg.** With a default, a caller could set `syzygy_path`, forget the handle, and silently lose tablebase adjudication. The first implementation guarded this with a runtime warning, but that fired *once per half-move* when the tablebase failed to open — roughly a thousand misleading warnings per game — so the guard is now static: pyright strict catches an omitted handle at type-check time.

Open failures (missing or unreadable directory) are logged exactly once and disable adjudication for that game rather than killing it. Adjudication **outcomes are unchanged** in every case traced: valid path, missing path, empty directory, partial tablebase.

## Verification

```
179 passed, 2 deselected   (173 on main)
pyright strict: 0 errors   ruff check: passed   ruff format: 90 files clean
```

Backend (94) and shared (186) suites confirmed unaffected. The "opened once" test is non-vacuous: it drives a real 4-probe endgame and asserts `open_tablebase` called once while `probe_wdl` is called 4 times on that one handle, so the old per-probe code fails it. A separate test runs two sequential games and asserts open×2/close×2, which pins "once per game" rather than "once per process" and would catch the rejected global-cache design. Deleting the `close()` call makes 6 tests fail.

`sprt-runner/` only; no CLI flags or JSON-lines schema touched.

Note: nothing currently sets `AdjudicationConfig.syzygy_path` from the runner's CLI surface, so this path is dormant in production — filed separately as a follow-up rather than scoped into this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)