### PR TITLE
feat: build the Game Replay page with an eval graph

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,10 +2,42 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { App } from './App'
+import type { GameDetail } from './services/api'
 
-vi.mock('./services/api', () => ({
-  fetchEngines: vi.fn().mockResolvedValue([]),
-}))
+// vi.mock factories are hoisted above module-scope declarations, so the
+// fixture must be created inside vi.hoisted rather than referenced from a
+// plain top-level const (which would hit a temporal-dead-zone error).
+const { mockGame } = vi.hoisted(() => {
+  const mockGame: GameDetail = {
+    id: 'abc123',
+    white_engine: 'Stockfish',
+    black_engine: 'Leela',
+    result: '1-0',
+    moves: [],
+    created_at: '2025-06-15T10:30:00Z',
+    opening_name: null,
+    sprt_test_id: null,
+    start_fen: null,
+    time_control: null,
+  }
+  return { mockGame }
+})
+
+// Spread the real module (via importOriginal) rather than replacing it
+// outright, so exports GameReplayPage depends on at runtime — notably
+// `ApiError`, used in its catch branch — stay real. A factory that omits
+// ApiError only "works" by accident: it's invisible today because
+// fetchGame never rejects in this file, but the first test that made it
+// reject would hit Vitest's "No 'ApiError' export is defined on the mock"
+// instead of exercising the intended code path.
+vi.mock('./services/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./services/api')>()
+  return {
+    ...actual,
+    fetchEngines: vi.fn().mockResolvedValue([]),
+    fetchGame: vi.fn().mockResolvedValue(mockGame),
+  }
+})
 
 describe('App', () => {
   it('renders the Play page by default', async () => {
@@ -50,12 +82,15 @@ describe('Routing', () => {
     expect(screen.getByRole('heading', { name: 'Game Replay' })).toBeInTheDocument()
   })
 
-  it('renders Game Replay page at /games/:id', () => {
+  it('renders Game Replay page at /games/:id', async () => {
     render(
       <MemoryRouter initialEntries={['/games/abc123']}>
         <App />
       </MemoryRouter>,
     )
     expect(screen.getByRole('heading', { name: 'Game Replay' })).toBeInTheDocument()
+    // fetchGame resolves asynchronously — wait for the resulting state
+    // update to settle inside act() before the test (and mock) teardown.
+    await waitFor(() => expect(screen.getByText('Stockfish')).toBeInTheDocument())
   })
 })

--- a/frontend/src/components/EvalGraph/EvalGraph.test.tsx
+++ b/frontend/src/components/EvalGraph/EvalGraph.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { EvalGraph } from './EvalGraph'
+import type { EvalGraphPoint } from './EvalGraph'
+
+describe('EvalGraph', () => {
+  it('renders an empty-state message when there are no points', () => {
+    render(<EvalGraph points={[]} currentMoveIndex={-1} />)
+    expect(screen.getByText('No evaluation data')).toBeInTheDocument()
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+
+  it('renders an empty-state message when every point has no recorded eval', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: null, scoreMate: null },
+      { scoreCp: null, scoreMate: null },
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    expect(screen.getByText('No evaluation data')).toBeInTheDocument()
+  })
+
+  it('renders an accessible chart with a data-bearing label when eval data is present', () => {
+    const points: EvalGraphPoint[] = [{ scoreCp: 20, scoreMate: null }]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    // The label carries the point count so a wrong/empty data set is
+    // detectable non-visually too, not just "some chart exists".
+    expect(screen.getByRole('img', { name: /Evaluation graph over 1 moves/ })).toBeInTheDocument()
+  })
+
+  it('includes the current move in the accessible label when one is set', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: 20, scoreMate: null },
+      { scoreCp: -10, scoreMate: null },
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={1} />)
+    expect(screen.getByRole('img', { name: /currently showing move 2/ })).toBeInTheDocument()
+  })
+
+  it('renders one point per non-null eval and skips null ones', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: 20, scoreMate: null },
+      { scoreCp: null, scoreMate: null },
+      { scoreCp: -30, scoreMate: null },
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    expect(screen.getByTestId('eval-graph-point-0')).toBeInTheDocument()
+    expect(screen.queryByTestId('eval-graph-point-1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('eval-graph-point-2')).toBeInTheDocument()
+  })
+
+  it('does not render a connecting line with fewer than two valid points', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: 20, scoreMate: null },
+      { scoreCp: null, scoreMate: null },
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    expect(screen.queryByTestId('eval-graph-line')).not.toBeInTheDocument()
+  })
+
+  it('renders a connecting line with two or more valid points', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: 20, scoreMate: null },
+      { scoreCp: -30, scoreMate: null },
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    expect(screen.getByTestId('eval-graph-line')).toBeInTheDocument()
+  })
+
+  it('marks the current move point with data-current and a visible highlight', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: 20, scoreMate: null },
+      { scoreCp: -30, scoreMate: null },
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={1} />)
+    const current = screen.getByTestId('eval-graph-point-1')
+    const other = screen.getByTestId('eval-graph-point-0')
+    expect(other).toHaveAttribute('data-current', 'false')
+    expect(current).toHaveAttribute('data-current', 'true')
+    // Assert the actual visible cue, not just the test-only attribute —
+    // deleting the highlight styling entirely would still leave
+    // data-current="true" set and this test green otherwise.
+    expect(current).toHaveClass('fill-yellow-400')
+    expect(current).toHaveAttribute('r', '4')
+    expect(other).not.toHaveClass('fill-yellow-400')
+    expect(other).toHaveAttribute('r', '2')
+  })
+
+  it('marks no point as current when currentMoveIndex is -1 (start position)', () => {
+    const points: EvalGraphPoint[] = [{ scoreCp: 20, scoreMate: null }]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    expect(screen.getByTestId('eval-graph-point-0')).toHaveAttribute('data-current', 'false')
+    expect(screen.queryByTestId('eval-graph-current-line')).not.toBeInTheDocument()
+  })
+
+  it('draws a current-move rule even when the current move has no recorded eval', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: 20, scoreMate: null },
+      { scoreCp: null, scoreMate: null },
+      { scoreCp: -30, scoreMate: null },
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={1} />)
+    // Index 1 has no eval, so it contributes no circle...
+    expect(screen.queryByTestId('eval-graph-point-1')).not.toBeInTheDocument()
+    // ...but the current-move indicator must still mark that position.
+    expect(screen.getByTestId('eval-graph-current-line')).toBeInTheDocument()
+  })
+
+  it('clamps a forced mate to the top of the chart for White and the bottom for Black', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: null, scoreMate: 4 }, // White mates
+      { scoreCp: null, scoreMate: -4 }, // Black mates
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    const whiteMatePoint = screen.getByTestId('eval-graph-point-0')
+    const blackMatePoint = screen.getByTestId('eval-graph-point-1')
+    const whiteY = Number(whiteMatePoint.getAttribute('cy'))
+    const blackY = Number(blackMatePoint.getAttribute('cy'))
+    // Lower cy = higher on the chart. White's mate (good for White) should
+    // plot above (smaller y) Black's mate (bad for White).
+    expect(whiteY).toBeLessThan(blackY)
+  })
+
+  it('clamps very large centipawn scores to the same edge as a forced mate', () => {
+    const points: EvalGraphPoint[] = [
+      { scoreCp: 5000, scoreMate: null },
+      { scoreCp: null, scoreMate: 1 },
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    const outlierY = screen.getByTestId('eval-graph-point-0').getAttribute('cy')
+    const mateY = screen.getByTestId('eval-graph-point-1').getAttribute('cy')
+    expect(outlierY).toBe(mateY)
+  })
+
+  it('treats scoreMate 0 as Black-favoured, matching EvalBar own > 0 boundary', () => {
+    // EvalBar.computeWhitePercent uses `scoreMate > 0 ? 100 : 0`, i.e. a
+    // mate of exactly 0 reads as bad for White (0%, bottom of the bar).
+    // The graph must agree, not use a `>= 0` test that would plot it at
+    // the top instead.
+    const points: EvalGraphPoint[] = [
+      { scoreCp: null, scoreMate: 0 },
+      { scoreCp: null, scoreMate: 4 }, // clearly White-favoured, for comparison
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    const mateZeroY = Number(screen.getByTestId('eval-graph-point-0').getAttribute('cy'))
+    const whiteMateY = Number(screen.getByTestId('eval-graph-point-1').getAttribute('cy'))
+    expect(mateZeroY).toBeGreaterThan(whiteMateY)
+  })
+
+  it('draws a dashed zero reference line', () => {
+    const points: EvalGraphPoint[] = [{ scoreCp: 20, scoreMate: null }]
+    const { container } = render(<EvalGraph points={points} currentMoveIndex={-1} />)
+    const zeroLine = container.querySelector('line')
+    expect(zeroLine).toBeInTheDocument()
+  })
+
+  it('pins the exact x/y geometry for a known fixture, including a gap at a null-eval index', () => {
+    // points[1] is null and must leave a gap (point 2 stays at its own
+    // x-position, x is not compacted to slot 1) rather than being
+    // silently dropped from the index space.
+    const points: EvalGraphPoint[] = [
+      { scoreCp: 500, scoreMate: null }, // index 0: max clamp, cy at the very top
+      { scoreCp: null, scoreMate: null }, // index 1: no point
+      { scoreCp: -500, scoreMate: null }, // index 2: max negative clamp, cy at the very bottom
+    ]
+    render(<EvalGraph points={points} currentMoveIndex={-1} />)
+
+    // VIEW_WIDTH=600, PADDING=10 => innerWidth=580; lastIndex = 2.
+    // xAt(0) = 10 + (0/2)*580 = 10; xAt(2) = 10 + (2/2)*580 = 590.
+    expect(screen.getByTestId('eval-graph-point-0')).toHaveAttribute('cx', '10')
+    expect(screen.getByTestId('eval-graph-point-2')).toHaveAttribute('cx', '590')
+    expect(screen.queryByTestId('eval-graph-point-1')).not.toBeInTheDocument()
+
+    // A positive cp must plot above (smaller cy than) a negative cp.
+    const topY = Number(screen.getByTestId('eval-graph-point-0').getAttribute('cy'))
+    const bottomY = Number(screen.getByTestId('eval-graph-point-2').getAttribute('cy'))
+    expect(topY).toBeLessThan(bottomY)
+
+    // The connecting line jumps straight from index 0 to index 2 (a gap
+    // at the null index), not to a compacted x for the second point.
+    expect(screen.getByTestId('eval-graph-line')).toHaveAttribute(
+      'd',
+      `M 10 ${topY} L 590 ${bottomY}`,
+    )
+  })
+
+  it('shrinks point radius once the game is long enough for dots to overlap', () => {
+    const many: EvalGraphPoint[] = Array.from({ length: 200 }, (_, i) => ({
+      scoreCp: i % 2 === 0 ? 10 : -10,
+      scoreMate: null,
+    }))
+    render(<EvalGraph points={many} currentMoveIndex={-1} />)
+    expect(screen.getByTestId('eval-graph-point-0')).toHaveAttribute('r', '1.5')
+  })
+})

--- a/frontend/src/components/EvalGraph/EvalGraph.tsx
+++ b/frontend/src/components/EvalGraph/EvalGraph.tsx
@@ -1,0 +1,207 @@
+/**
+ * Hand-rolled SVG line chart of centipawn evaluation over the course of a
+ * game. No charting library is used — dependencies are exactly pinned by
+ * policy and this component is simple enough not to warrant one.
+ *
+ * Contract with the caller (see GameReplayPage, which owns the mover→White
+ * perspective conversion):
+ * - Every point must already be in White's perspective — positive means
+ *   White is better, negative means Black is better — matching the
+ *   convention `EvalBar` uses. This component does no sign flipping.
+ * - `scoreMate` takes priority over `scoreCp` on a point (mirrors EvalBar's
+ *   own formatScore/computeWhitePercent logic): a forced mate clamps to
+ *   +/-MATE_CLAMP_CP so it plots on the same fixed y-axis domain as
+ *   centipawn scores rather than needing its own scale.
+ * - A point with both fields null (no evaluation recorded for that move) is
+ *   skipped: it contributes no vertex, so the line is drawn as a straight
+ *   segment directly between its neighbours instead of dipping to zero.
+ *   A set of points that are all null renders an empty-state message
+ *   instead of an empty/broken chart.
+ *
+ * Y-axis domain is fixed at [-MATE_CLAMP_CP, MATE_CLAMP_CP] centipawns
+ * (+/-10 pawns) rather than auto-scaled to the data, so the chart's shape is
+ * comparable across games and an outlier score can't blow out the scale.
+ * `x` is plotted on the raw half-move (ply) index into `points`, not a
+ * full-move number — deriving full-move/side labels needs to know which
+ * side moved first (see GameReplayPage's `toWhitePerspective`), which this
+ * component intentionally has no knowledge of.
+ *
+ * A forced mate of exactly 0 (`scoreMate === 0`) is treated as bad for the
+ * side that moved — i.e. `scoreMate > 0` clamps to the top (White better),
+ * anything else (including `0` and `-0`) clamps to the bottom — matching
+ * `EvalBar`'s own `computeWhitePercent` (`scoreMate > 0 ? 100 : 0`) so the
+ * two components never disagree at that boundary.
+ *
+ * The current move is marked two ways so the indicator survives even when
+ * that move has no recorded eval: an enlarged/coloured point when a value
+ * exists, and a vertical rule (`data-testid="eval-graph-current-line"`) at
+ * its x-position regardless.
+ *
+ * Test seam: the wrapper carries `data-testid="eval-graph"`; when data is
+ * present the `<svg>` has `role="img"` with an accessible name, the
+ * connecting line carries `data-testid="eval-graph-line"`, and each plotted
+ * point carries `data-testid="eval-graph-point-{index}"` (index into
+ * `points`) plus `data-current="true"/"false"`.
+ */
+
+export interface EvalGraphPoint {
+  /** Centipawn score, White's perspective, or null if not recorded. */
+  scoreCp: number | null
+  /** Mate-in-N, White's perspective (positive = White mates), or null. */
+  scoreMate: number | null
+}
+
+export interface EvalGraphProps {
+  /** One point per half-move, in game order (index = move index). */
+  points: EvalGraphPoint[]
+  /** Index into `points` to highlight, or -1 for "no move played yet". */
+  currentMoveIndex: number
+  /** SVG viewBox height in logical (unitless) units; width is fixed. */
+  height?: number
+}
+
+const VIEW_WIDTH = 600
+const DEFAULT_HEIGHT = 150
+const PADDING = 10
+/** Centipawn magnitude a forced mate (and any evaluation outlier) clamps to. */
+const MATE_CLAMP_CP = 1000
+
+interface ResolvedEntry {
+  index: number
+  value: number
+}
+
+function resolveValue(point: EvalGraphPoint): number | null {
+  if (point.scoreMate !== null) {
+    // `> 0`, not `>= 0`: mirrors EvalBar's computeWhitePercent so a mate of
+    // exactly 0 (and the `-0` a sign-flip of it can produce) plots at the
+    // same edge the eval bar colours as Black-favoured, not White-favoured.
+    return point.scoreMate > 0 ? MATE_CLAMP_CP : -MATE_CLAMP_CP
+  }
+  if (point.scoreCp !== null) {
+    return Math.max(-MATE_CLAMP_CP, Math.min(MATE_CLAMP_CP, point.scoreCp))
+  }
+  return null
+}
+
+export function EvalGraph({
+  points,
+  currentMoveIndex,
+  height = DEFAULT_HEIGHT,
+}: EvalGraphProps): React.JSX.Element {
+  const innerWidth = VIEW_WIDTH - PADDING * 2
+  const innerHeight = height - PADDING * 2
+  // Guard against divide-by-zero when there's only a single move to plot.
+  const lastIndex = Math.max(points.length - 1, 1)
+
+  const xAt = (index: number): number => PADDING + (index / lastIndex) * innerWidth
+  const yAt = (value: number): number =>
+    PADDING + ((MATE_CLAMP_CP - value) / (2 * MATE_CLAMP_CP)) * innerHeight
+
+  const validEntries: ResolvedEntry[] = points.reduce<ResolvedEntry[]>((acc, point, index) => {
+    const value = resolveValue(point)
+    if (value !== null) acc.push({ index, value })
+    return acc
+  }, [])
+
+  const linePath = validEntries
+    .map((entry, i) => `${i === 0 ? 'M' : 'L'} ${xAt(entry.index)} ${yAt(entry.value)}`)
+    .join(' ')
+
+  // On a long game, per-move dots at a fixed radius overlap into a solid
+  // band and drown out the current-move marker. Shrink both radii once
+  // points are packed tighter than they are wide.
+  const isDense = validEntries.length > 80
+  const pointRadius = isDense ? 1.5 : 2
+  const currentPointRadius = isDense ? 3 : 4
+
+  const graphLabel =
+    currentMoveIndex >= 0
+      ? `Evaluation graph over ${points.length} moves, currently showing move ${currentMoveIndex + 1}`
+      : `Evaluation graph over ${points.length} moves`
+
+  return (
+    <div data-testid="eval-graph" className="w-full">
+      {validEntries.length === 0 ? (
+        <p className="p-2 text-sm text-gray-400" data-testid="eval-graph-empty">
+          No evaluation data
+        </p>
+      ) : (
+        <svg
+          role="img"
+          aria-label={graphLabel}
+          viewBox={`0 0 ${VIEW_WIDTH} ${height}`}
+          className="h-auto w-full"
+          preserveAspectRatio="none"
+        >
+          {/* Zero-eval reference line */}
+          <line
+            x1={PADDING}
+            y1={yAt(0)}
+            x2={VIEW_WIDTH - PADDING}
+            y2={yAt(0)}
+            className="stroke-gray-600"
+            strokeDasharray="4 4"
+            strokeWidth={1}
+          />
+          {/* Y-axis extremes, so the fixed +/-10 pawn domain is legible. */}
+          <text x={PADDING + 2} y={PADDING + 8} className="fill-gray-500" style={{ fontSize: 8 }}>
+            +10
+          </text>
+          <text x={PADDING + 2} y={yAt(0) - 2} className="fill-gray-500" style={{ fontSize: 8 }}>
+            0
+          </text>
+          <text
+            x={PADDING + 2}
+            y={height - PADDING - 2}
+            className="fill-gray-500"
+            style={{ fontSize: 8 }}
+          >
+            -10
+          </text>
+          {validEntries.length > 1 && (
+            <path
+              d={linePath}
+              fill="none"
+              className="stroke-blue-400"
+              strokeWidth={2}
+              data-testid="eval-graph-line"
+            />
+          )}
+          {/*
+           * Current-move indicator, drawn independently of whether that
+           * move has a plotted point below — a vertical rule always marks
+           * the position, even for a null-eval current move that has no
+           * circle of its own.
+           */}
+          {currentMoveIndex >= 0 && currentMoveIndex < points.length && (
+            <line
+              data-testid="eval-graph-current-line"
+              x1={xAt(currentMoveIndex)}
+              x2={xAt(currentMoveIndex)}
+              y1={PADDING}
+              y2={height - PADDING}
+              className="stroke-yellow-400"
+              strokeWidth={1}
+              strokeDasharray="2 2"
+            />
+          )}
+          {validEntries.map((entry) => {
+            const isCurrent = entry.index === currentMoveIndex
+            return (
+              <circle
+                key={entry.index}
+                data-testid={`eval-graph-point-${entry.index}`}
+                data-current={isCurrent}
+                cx={xAt(entry.index)}
+                cy={yAt(entry.value)}
+                r={isCurrent ? currentPointRadius : pointRadius}
+                className={isCurrent ? 'fill-yellow-400' : 'fill-blue-400'}
+              />
+            )
+          })}
+        </svg>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/GameReplayPage.test.tsx
+++ b/frontend/src/pages/GameReplayPage.test.tsx
@@ -1,10 +1,584 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { GameReplayPage } from './GameReplayPage'
+import { fetchGame, ApiError } from '../services/api'
+import type { GameDetail } from '../services/api'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../services/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/api')>()
+  return {
+    ...actual,
+    fetchGame: vi.fn(),
+  }
+})
+
+vi.mock('react-chessboard', () => ({
+  Chessboard: ({ options }: { options?: Record<string, unknown> }) => (
+    <div
+      data-testid="chessboard"
+      data-position={String(options?.position ?? '')}
+      data-orientation={String(options?.boardOrientation ?? 'white')}
+    />
+  ),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STANDARD_INITIAL_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+
+function renderAtPath(path: string): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="games/:id?" element={<GameReplayPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// Ruy Lopez opening: 1. e4 e5 2. Nf3 Nc6 3. Bb5
+// Sign convention under test: score_cp/score_mate on a Move are stored from
+// the perspective of whichever side just moved. White moves live at even
+// indices (already White-relative); Black moves live at odd indices (must be
+// negated to read as White-relative). Move 3 (Nc6, black, index 3) carries no
+// recorded eval at all. Move 4 (Bb5, white, index 4) is a forced mate.
+const sampleGame: GameDetail = {
+  id: 'game-1',
+  white_engine: 'Stockfish',
+  black_engine: 'Leela',
+  result: '1-0',
+  moves: [
+    {
+      uci: 'e2e4',
+      san: 'e4',
+      fen_after: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1',
+      score_cp: 20,
+      score_mate: null,
+      depth: 18,
+      seldepth: 22,
+      pv: ['e7e5', 'g1f3', 'b8c6'],
+      nodes: 100000,
+      time_ms: 500,
+      clock_white_ms: null,
+      clock_black_ms: null,
+    },
+    {
+      uci: 'e7e5',
+      san: 'e5',
+      fen_after: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2',
+      score_cp: 10,
+      score_mate: null,
+      depth: 18,
+      seldepth: 20,
+      pv: ['g1f3', 'b8c6', 'f1b5'],
+      nodes: 90000,
+      time_ms: 480,
+      clock_white_ms: null,
+      clock_black_ms: null,
+    },
+    {
+      uci: 'g1f3',
+      san: 'Nf3',
+      fen_after: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2',
+      score_cp: 30,
+      score_mate: null,
+      depth: 19,
+      seldepth: 24,
+      pv: ['b8c6', 'f1b5', 'a7a6'],
+      nodes: 120000,
+      time_ms: 510,
+      clock_white_ms: null,
+      clock_black_ms: null,
+    },
+    {
+      uci: 'b8c6',
+      san: 'Nc6',
+      fen_after: 'rnbqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3',
+      score_cp: null,
+      score_mate: null,
+      depth: null,
+      seldepth: null,
+      pv: [],
+      nodes: null,
+      time_ms: null,
+      clock_white_ms: null,
+      clock_black_ms: null,
+    },
+    {
+      uci: 'f1b5',
+      san: 'Bb5',
+      fen_after: 'rnbqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3',
+      score_cp: null,
+      score_mate: 3,
+      depth: 25,
+      seldepth: 30,
+      pv: ['a7a6', 'b5a4'],
+      nodes: 500000,
+      time_ms: 800,
+      clock_white_ms: null,
+      clock_black_ms: null,
+    },
+  ],
+  created_at: '2025-06-15T10:30:00Z',
+  opening_name: 'Ruy Lopez',
+  sprt_test_id: null,
+  start_fen: null,
+  time_control: null,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe('GameReplayPage', () => {
-  it('renders the heading', () => {
-    render(<GameReplayPage />)
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fetchGame).mockResolvedValue(sampleGame)
+  })
+
+  it('renders the heading', async () => {
+    renderAtPath('/games/game-1')
     expect(screen.getByRole('heading', { name: 'Game Replay' })).toBeInTheDocument()
+    // Wait for the async fetchGame to settle so state updates land inside act().
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+  })
+
+  // -----------------------------------------------------------------------
+  // No-id route
+  // -----------------------------------------------------------------------
+
+  it('shows a message and does not fetch when no id is present', () => {
+    renderAtPath('/games')
+    expect(screen.getByText('Select a game to view its replay.')).toBeInTheDocument()
+    expect(fetchGame).not.toHaveBeenCalled()
+  })
+
+  // -----------------------------------------------------------------------
+  // Loading
+  // -----------------------------------------------------------------------
+
+  it('shows a loading indicator while the game is being fetched', () => {
+    vi.mocked(fetchGame).mockReturnValue(new Promise(() => {}))
+    renderAtPath('/games/game-1')
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  // -----------------------------------------------------------------------
+  // Metadata
+  // -----------------------------------------------------------------------
+
+  it('loads the game and displays its metadata under the correct labels', async () => {
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledWith('game-1'))
+    await waitFor(() => expect(screen.getByText('Stockfish')).toBeInTheDocument())
+    // Assert each value sits directly under its label (dt -> dd), not just
+    // that the string appears somewhere on the page — catches a swapped
+    // White/Black (or any other mislabelled) field that plain getByText
+    // would miss entirely.
+    expect(screen.getByText('White').nextElementSibling).toHaveTextContent('Stockfish')
+    expect(screen.getByText('Black').nextElementSibling).toHaveTextContent('Leela')
+    expect(screen.getByText('Result').nextElementSibling).toHaveTextContent('1-0')
+    expect(screen.getByText('Opening').nextElementSibling).toHaveTextContent('Ruy Lopez')
+    expect(screen.getByText('Date').nextElementSibling).toHaveTextContent('2025-06-15')
+  })
+
+  it('shows a placeholder date instead of a raw fragment for a malformed created_at', async () => {
+    vi.mocked(fetchGame).mockResolvedValue({ ...sampleGame, created_at: 'not-a-date' })
+    renderAtPath('/games/game-1')
+    await waitFor(() =>
+      expect(screen.getByText('Date').nextElementSibling).toHaveTextContent('Unknown date'),
+    )
+  })
+
+  it('falls back to a placeholder when opening_name is null', async () => {
+    vi.mocked(fetchGame).mockResolvedValue({ ...sampleGame, opening_name: null })
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByText('Unknown opening')).toBeInTheDocument())
+  })
+
+  // -----------------------------------------------------------------------
+  // 404 / error handling
+  // -----------------------------------------------------------------------
+
+  it('shows a friendly message when the game is not found', async () => {
+    vi.mocked(fetchGame).mockRejectedValue(new ApiError(404, 'Game not found'))
+    renderAtPath('/games/missing')
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Game not found.'))
+    expect(screen.queryByTestId('chessboard')).not.toBeInTheDocument()
+  })
+
+  it('shows a generic error message for non-404 failures', async () => {
+    vi.mocked(fetchGame).mockRejectedValue(new Error('Network error'))
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Network error'))
+  })
+
+  it('falls back to a generic message when the error has an empty message', async () => {
+    // response.statusText is always '' over HTTP/2, and a JSON body with
+    // `detail: ""` hits the same path — the alert must never render blank.
+    vi.mocked(fetchGame).mockRejectedValue(new ApiError(500, ''))
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Failed to load game'))
+  })
+
+  // -----------------------------------------------------------------------
+  // Start position
+  // -----------------------------------------------------------------------
+
+  it('shows the starting position and a neutral eval bar before any navigation', async () => {
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+    expect(screen.getByTestId('chessboard')).toHaveAttribute('data-position', STANDARD_INITIAL_FEN)
+    expect(screen.getByText('+0.0')).toBeInTheDocument()
+  })
+
+  // -----------------------------------------------------------------------
+  // Navigation buttons
+  // -----------------------------------------------------------------------
+
+  it('navigates through the game with first/previous/next/last controls', async () => {
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    expect(screen.getByRole('button', { name: 'First' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Last' })).toBeEnabled()
+
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[0].fen_after,
+    )
+    expect(screen.getByText('+0.2')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[1].fen_after,
+    )
+    expect(screen.getByText('−0.1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Previous' }))
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[0].fen_after,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Last' }))
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[4].fen_after,
+    )
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Last' })).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'First' }))
+    expect(screen.getByTestId('chessboard')).toHaveAttribute('data-position', STANDARD_INITIAL_FEN)
+  })
+
+  // -----------------------------------------------------------------------
+  // MoveList click
+  // -----------------------------------------------------------------------
+
+  it('jumps to the clicked move in the move list', async () => {
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    // Click via role/name (not getByText, which would still resolve a
+    // non-interactive <span>) so this also pins the move as an accessible,
+    // keyboard-reachable control.
+    await user.click(screen.getByRole('button', { name: /Nf3/ }))
+
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[2].fen_after,
+    )
+    expect(screen.getByText('+0.3')).toBeInTheDocument()
+    expect(screen.getByTestId('pv-line')).toHaveTextContent('b8c6 f1b5 a7a6')
+  })
+
+  // -----------------------------------------------------------------------
+  // Keyboard navigation
+  // -----------------------------------------------------------------------
+
+  it('navigates with arrow keys (left/right step, up/down first/last)', async () => {
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    await user.keyboard('{ArrowRight}')
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[0].fen_after,
+    )
+
+    await user.keyboard('{ArrowRight}')
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[1].fen_after,
+    )
+
+    await user.keyboard('{ArrowLeft}')
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[0].fen_after,
+    )
+
+    await user.keyboard('{ArrowDown}')
+    expect(screen.getByTestId('chessboard')).toHaveAttribute(
+      'data-position',
+      sampleGame.moves[4].fen_after,
+    )
+
+    await user.keyboard('{ArrowUp}')
+    expect(screen.getByTestId('chessboard')).toHaveAttribute('data-position', STANDARD_INITIAL_FEN)
+  })
+
+  it('ignores arrow keys while focus is inside a text input', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/games/game-1']}>
+        <Routes>
+          <Route
+            path="games/:id?"
+            element={
+              <>
+                <input aria-label="Unrelated field" />
+                <GameReplayPage />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    await user.click(screen.getByLabelText('Unrelated field'))
+    await user.keyboard('{ArrowRight}')
+
+    expect(screen.getByTestId('chessboard')).toHaveAttribute('data-position', STANDARD_INITIAL_FEN)
+  })
+
+  it('ignores arrow keys while focus is inside a select element', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/games/game-1']}>
+        <Routes>
+          <Route
+            path="games/:id?"
+            element={
+              <>
+                <select aria-label="Unrelated select">
+                  <option value="a">a</option>
+                  <option value="b">b</option>
+                </select>
+                <GameReplayPage />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    await user.click(screen.getByLabelText('Unrelated select'))
+    await user.keyboard('{ArrowDown}')
+
+    expect(screen.getByTestId('chessboard')).toHaveAttribute('data-position', STANDARD_INITIAL_FEN)
+  })
+
+  it('removes the keydown listener on unmount so a later keypress has no effect', async () => {
+    const user = userEvent.setup()
+    const { unmount } = renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    unmount()
+    // No component is mounted to receive this — if the listener leaked,
+    // this would throw (or silently mutate unmounted state) instead of
+    // being a no-op.
+    await user.keyboard('{ArrowRight}')
+    expect(screen.queryByTestId('chessboard')).not.toBeInTheDocument()
+  })
+
+  // -----------------------------------------------------------------------
+  // Board orientation
+  // -----------------------------------------------------------------------
+
+  it('defaults board orientation to white and flips on request', async () => {
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    expect(screen.getByTestId('chessboard')).toHaveAttribute('data-orientation', 'white')
+    expect(screen.getByRole('button', { name: 'Flip Board' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+    expect(screen.getByRole('meter')).toHaveAttribute('data-orientation', 'white')
+
+    await user.click(screen.getByRole('button', { name: 'Flip Board' }))
+    expect(screen.getByTestId('chessboard')).toHaveAttribute('data-orientation', 'black')
+    // The eval bar's own orientation must track the flip too, or it reads
+    // upside-down relative to the board.
+    expect(screen.getByRole('button', { name: 'Flip Board' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByRole('meter')).toHaveAttribute('data-orientation', 'black')
+  })
+
+  // -----------------------------------------------------------------------
+  // Forced mate
+  // -----------------------------------------------------------------------
+
+  it('shows a forced-mate score and highlights it on the eval graph', async () => {
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Last' }))
+
+    expect(screen.getByText('M3')).toBeInTheDocument()
+    expect(screen.getByTestId('eval-graph-point-4')).toHaveAttribute('data-current', 'true')
+  })
+
+  // -----------------------------------------------------------------------
+  // Eval graph data points
+  // -----------------------------------------------------------------------
+
+  it('renders one eval graph point per move with a recorded eval, skipping moves with none', async () => {
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    expect(screen.getByTestId('eval-graph-point-0')).toBeInTheDocument()
+    expect(screen.getByTestId('eval-graph-point-1')).toBeInTheDocument()
+    expect(screen.getByTestId('eval-graph-point-2')).toBeInTheDocument()
+    expect(screen.queryByTestId('eval-graph-point-3')).not.toBeInTheDocument()
+    expect(screen.getByTestId('eval-graph-point-4')).toBeInTheDocument()
+    expect(screen.getByTestId('eval-graph-line')).toBeInTheDocument()
+  })
+
+  // -----------------------------------------------------------------------
+  // Zero-move game
+  // -----------------------------------------------------------------------
+
+  it('renders a zero-move game without crashing', async () => {
+    vi.mocked(fetchGame).mockResolvedValue({ ...sampleGame, moves: [] })
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    expect(screen.getByText('No moves')).toBeInTheDocument()
+    expect(screen.getByText('No evaluation data')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'First' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Last' })).toBeDisabled()
+  })
+
+  // -----------------------------------------------------------------------
+  // All-null-eval game
+  // -----------------------------------------------------------------------
+
+  it('renders a game whose every move has a null eval without crashing', async () => {
+    const allNullGame: GameDetail = {
+      ...sampleGame,
+      moves: sampleGame.moves.map((m) => ({ ...m, score_cp: null, score_mate: null })),
+    }
+    vi.mocked(fetchGame).mockResolvedValue(allNullGame)
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    expect(screen.getByText('No evaluation data')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    // EvalBar has no "no data" state of its own and renders a neutral
+    // +0.0 for a missing score; a distinct caption must make clear that
+    // this is "no eval recorded", not "the engine evaluated this as
+    // equal" — otherwise it silently contradicts EvalGraph's own "No
+    // evaluation data" message for the same move.
+    expect(screen.getByText('+0.0')).toBeInTheDocument()
+    expect(screen.getByTestId('eval-bar-no-data')).toBeInTheDocument()
+  })
+
+  // -----------------------------------------------------------------------
+  // No recorded eval for a single move
+  // -----------------------------------------------------------------------
+
+  it('shows a "no data" caption instead of a fabricated eval for a move with no recorded score', async () => {
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    expect(screen.queryByTestId('eval-bar-no-data')).not.toBeInTheDocument()
+
+    // Navigate to move index 3 (Nc6), which carries no recorded eval.
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(screen.getByTestId('eval-bar-no-data')).toBeInTheDocument()
+    // The eval graph agrees: no data point, but the current-move rule
+    // still marks the position.
+    expect(screen.queryByTestId('eval-graph-point-3')).not.toBeInTheDocument()
+    expect(screen.getByTestId('eval-graph-current-line')).toBeInTheDocument()
+  })
+
+  // -----------------------------------------------------------------------
+  // Status line
+  // -----------------------------------------------------------------------
+
+  it('reports the current move in the status line with full-move notation', async () => {
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    expect(screen.getByRole('status')).toHaveTextContent('Starting position')
+
+    await user.click(screen.getByRole('button', { name: 'Last' }))
+    // Index 4 (Bb5) is White's 3rd move.
+    expect(screen.getByRole('status')).toHaveTextContent('3. Bb5')
+    expect(screen.getByRole('status')).toHaveTextContent('move 5 of 5')
+  })
+
+  // -----------------------------------------------------------------------
+  // Eval sign convention: mover derived from start_fen, not index parity
+  // -----------------------------------------------------------------------
+
+  it('derives the mover from a black-to-move start_fen instead of assuming White plays first', async () => {
+    const blackToMoveStartFen = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2'
+    const blackStartGame: GameDetail = {
+      ...sampleGame,
+      start_fen: blackToMoveStartFen,
+      // moves[0] is now Black's move: raw score_cp is from Black's own
+      // point of view (Black is +3.0), so White's perspective must be
+      // -3.0 — the opposite of what index-parity (index 0 => "White")
+      // would produce.
+      moves: [{ ...sampleGame.moves[0], score_cp: 300 }],
+    }
+    vi.mocked(fetchGame).mockResolvedValue(blackStartGame)
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    // The start position itself must render the game's actual start_fen,
+    // not silently fall back to the standard initial position.
+    expect(screen.getByTestId('chessboard')).toHaveAttribute('data-position', blackToMoveStartFen)
+
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    expect(screen.getByText('−3.0')).toBeInTheDocument()
+    expect(screen.queryByText('+3.0')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/GameReplayPage.tsx
+++ b/frontend/src/pages/GameReplayPage.tsx
@@ -1,7 +1,393 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { fetchGame, ApiError } from '../services/api'
+import type { GameDetail, Move } from '../services/api'
+import { Board } from '../components/Board/Board'
+import { EvalBar } from '../components/EvalBar/EvalBar'
+import { MoveList } from '../components/MoveList/MoveList'
+import type { MoveItem } from '../components/MoveList/MoveList'
+import { EvalGraph } from '../components/EvalGraph/EvalGraph'
+import type { EvalGraphPoint } from '../components/EvalGraph/EvalGraph'
+
+const STANDARD_INITIAL_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+
+/**
+ * Current-move indexing convention used throughout this page — applied
+ * consistently to the board FEN, EvalBar, PV display, MoveList highlight,
+ * and EvalGraph highlight:
+ *   -1  → the starting position, before any move has been played.
+ *   i   → the position immediately after `game.moves[i]` was played.
+ */
+const START_POSITION_INDEX = -1
+
+/** Board width (px) — also drives the height of the flanking eval bar and move list columns. */
+const BOARD_SIZE_PX = 400
+
+const NAV_BUTTON_CLASS =
+  'rounded bg-gray-700 px-3 py-1 text-white hover:bg-gray-600 disabled:cursor-not-allowed disabled:opacity-40'
+
+interface WhitePerspectiveScore {
+  scoreCp?: number
+  scoreMate?: number
+}
+
+/**
+ * True when the side to move in `fen`'s active-colour field is Black.
+ * Defaults to White (`false`) for a null/malformed FEN — the standard
+ * initial position always has White to move.
+ */
+function isBlackToMove(fen: string | null): boolean {
+  return (fen?.split(' ')[1] ?? 'w') === 'b'
+}
+
+/**
+ * Eval sign convention: `Move.score_cp` / `Move.score_mate` are stored from
+ * the perspective of whichever side made that move (the raw UCI `info
+ * score` convention). Moves strictly alternate colour starting from
+ * whoever is to move in `start_fen`, so the mover of `moves[index]` is
+ * White iff `(index % 2 === 1) !== firstMoverIsBlack` is false — i.e. we
+ * cannot assume index 0 is White's move, because `start_fen` (arbitrary
+ * opening-book positions, including odd-ply lines) may have Black to move
+ * first. `firstMoverIsBlack` must come from the active-colour field of
+ * `game.start_fen` (via {@link isBlackToMove}), not be assumed.
+ *
+ * EvalBar and EvalGraph both read scores as "White's advantage" (the
+ * conventional way to read an eval bar/graph), so a move played by Black
+ * has its sign flipped here before it reaches either component.
+ */
+function toWhitePerspective(
+  move: Move,
+  index: number,
+  firstMoverIsBlack: boolean,
+): WhitePerspectiveScore {
+  const isBlackMove = (index % 2 === 1) !== firstMoverIsBlack
+  const scoreCp = move.score_cp === null ? undefined : isBlackMove ? -move.score_cp : move.score_cp
+  const scoreMate =
+    move.score_mate === null ? undefined : isBlackMove ? -move.score_mate : move.score_mate
+  return { scoreCp, scoreMate }
+}
+
+/**
+ * Matches EvalBar's own formatScore exactly (mate takes priority over cp,
+ * same U+2212 minus glyph for negatives) so the same score never reads
+ * differently in the move list than it does on the eval bar.
+ */
+function formatAnnotation(score: WhitePerspectiveScore): string | undefined {
+  if (score.scoreMate !== undefined) return `(M${score.scoreMate})`
+  if (score.scoreCp !== undefined) {
+    const pawns = score.scoreCp / 100
+    if (score.scoreCp >= 0) return `(+${pawns.toFixed(1)})`
+    return `(−${Math.abs(pawns).toFixed(1)})`
+  }
+  return undefined
+}
+
+/**
+ * Full-move + side label for the status line, e.g. `3.` for a White move
+ * or `3...` for a Black move — matching MoveList's own (pre-existing,
+ * out-of-scope-here) even-index-is-White pairing convention, so the two
+ * displays never disagree with each other even though that shared
+ * convention is itself wrong for a Black-to-move `start_fen` (see
+ * `toWhitePerspective` above for the eval-sign fix; MoveList's grouping is
+ * a separate, pre-existing component this page does not modify).
+ */
+function fullMoveLabel(index: number): string {
+  const moveNumber = Math.floor(index / 2) + 1
+  return index % 2 === 0 ? `${moveNumber}.` : `${moveNumber}...`
+}
+
+/**
+ * Renders the date portion of an ISO timestamp. Parses rather than blindly
+ * slicing the string, so a malformed/empty `created_at` renders a clear
+ * placeholder instead of a truncated fragment of garbage.
+ */
+function formatGameDate(isoTimestamp: string): string {
+  const parsed = new Date(isoTimestamp)
+  return Number.isNaN(parsed.getTime()) ? 'Unknown date' : parsed.toISOString().slice(0, 10)
+}
+
+/**
+ * Route entry point. Delegates to {@link GameReplayView} for a given game
+ * id — remounting it (via `key={id}`) whenever the id changes is what
+ * resets all of that component's state, so no manual "reset on id change"
+ * logic is needed inside an effect.
+ */
 export function GameReplayPage(): React.JSX.Element {
+  const { id } = useParams<{ id?: string }>()
+
+  if (!id) {
+    return (
+      <main className="p-4">
+        <h1 className="mb-4 text-3xl font-bold">Game Replay</h1>
+        <p>Select a game to view its replay.</p>
+      </main>
+    )
+  }
+
+  return <GameReplayView key={id} id={id} />
+}
+
+interface GameReplayViewProps {
+  id: string
+}
+
+function GameReplayView({ id }: GameReplayViewProps): React.JSX.Element {
+  const [game, setGame] = useState<GameDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [notFound, setNotFound] = useState(false)
+  const [currentMoveIndex, setCurrentMoveIndex] = useState(START_POSITION_INDEX)
+  const [orientation, setOrientation] = useState<'white' | 'black'>('white')
+
+  // Fetch the game on mount (a fresh mount per id, via the `key` above).
+  // Every setState call below lives inside a promise callback rather than
+  // directly in the effect body, so mounting never triggers a synchronous
+  // extra render.
+  useEffect(() => {
+    let cancelled = false
+
+    fetchGame(id)
+      .then((data) => {
+        if (cancelled) return
+        setGame(data)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 404) {
+          setNotFound(true)
+        } else {
+          // `err.message` can legitimately be an empty string (e.g. a
+          // response with no `detail` and an HTTP/2 status line, which has
+          // no reason phrase) — `||` catches that case as well as
+          // non-Error rejections, so the alert is never silently blank.
+          setError((err instanceof Error && err.message) || 'Failed to load game')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  const moves = game?.moves ?? []
+
+  const goFirst = useCallback((): void => setCurrentMoveIndex(START_POSITION_INDEX), [])
+  const goLast = useCallback((): void => setCurrentMoveIndex(moves.length - 1), [moves.length])
+  const goNext = useCallback(
+    (): void => setCurrentMoveIndex((i) => Math.min(i + 1, moves.length - 1)),
+    [moves.length],
+  )
+  const goPrev = useCallback(
+    (): void => setCurrentMoveIndex((i) => Math.max(i - 1, START_POSITION_INDEX)),
+    [],
+  )
+
+  // Arrow-key navigation: Left/Right step one move at a time, Up/Down jump
+  // to the very first/last position. Delegates to the same goFirst/goPrev/
+  // goNext/goLast callbacks the nav buttons use, so the two input paths
+  // can never drift apart. Ignored while the user is typing/selecting in a
+  // form field so the shortcuts don't hijack normal text entry or native
+  // <select> option changes, and the listener is removed on unmount / when
+  // the game changes.
+  useEffect(() => {
+    if (!game) return
+
+    function isTypingTarget(target: EventTarget | null): boolean {
+      if (!(target instanceof HTMLElement)) return false
+      return target.closest('input, textarea, select, [contenteditable="true"]') !== null
+    }
+
+    function handleKeyDown(e: KeyboardEvent): void {
+      if (isTypingTarget(e.target)) return
+      switch (e.key) {
+        case 'ArrowLeft':
+          e.preventDefault()
+          goPrev()
+          break
+        case 'ArrowRight':
+          e.preventDefault()
+          goNext()
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          goFirst()
+          break
+        case 'ArrowDown':
+          e.preventDefault()
+          goLast()
+          break
+        default:
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [game, goFirst, goPrev, goNext, goLast])
+
+  const boardFen =
+    currentMoveIndex === START_POSITION_INDEX
+      ? (game?.start_fen ?? STANDARD_INITIAL_FEN)
+      : (moves[currentMoveIndex]?.fen_after ?? STANDARD_INITIAL_FEN)
+
+  // Who moves first is read from `start_fen`'s active-colour field, not
+  // assumed to be White — an opening-book position can have Black to move.
+  // See `toWhitePerspective`'s doc comment.
+  const firstMoverIsBlack = isBlackToMove(game?.start_fen ?? null)
+
+  const currentScore: WhitePerspectiveScore =
+    currentMoveIndex === START_POSITION_INDEX || !moves[currentMoveIndex]
+      ? {}
+      : toWhitePerspective(moves[currentMoveIndex], currentMoveIndex, firstMoverIsBlack)
+
+  const currentMoveHasEval =
+    currentMoveIndex !== START_POSITION_INDEX &&
+    (currentScore.scoreCp !== undefined || currentScore.scoreMate !== undefined)
+
+  const currentPv =
+    currentMoveIndex === START_POSITION_INDEX ? [] : (moves[currentMoveIndex]?.pv ?? [])
+
+  const moveItems: MoveItem[] = moves.map((m, i) => ({
+    san: m.san,
+    annotation: formatAnnotation(toWhitePerspective(m, i, firstMoverIsBlack)),
+  }))
+
+  const graphPoints: EvalGraphPoint[] = moves.map((m, i) => {
+    const score = toWhitePerspective(m, i, firstMoverIsBlack)
+    return {
+      scoreCp: score.scoreCp ?? null,
+      scoreMate: score.scoreMate ?? null,
+    }
+  })
+
+  const atStart = currentMoveIndex === START_POSITION_INDEX
+  const atEnd = currentMoveIndex >= moves.length - 1
+
   return (
-    <main>
-      <h1 className="text-3xl font-bold">Game Replay</h1>
+    <main className="p-4">
+      <h1 className="mb-4 text-3xl font-bold">Game Replay</h1>
+
+      {loading && <p>Loading…</p>}
+
+      {notFound && (
+        <p role="alert" className="rounded bg-red-900/50 p-3 text-red-200">
+          Game not found.
+        </p>
+      )}
+
+      {error && (
+        <div role="alert" className="rounded bg-red-900/50 p-3 text-red-200">
+          {error}
+        </div>
+      )}
+
+      {game && (
+        <div>
+          <dl className="mb-4 grid grid-cols-2 gap-x-6 gap-y-2 text-sm text-gray-300 sm:grid-cols-5">
+            <div>
+              <dt className="text-xs uppercase text-gray-500">White</dt>
+              <dd className="text-white">{game.white_engine}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-gray-500">Black</dt>
+              <dd className="text-white">{game.black_engine}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-gray-500">Result</dt>
+              <dd className="text-white">{game.result}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-gray-500">Opening</dt>
+              <dd className="text-white">{game.opening_name ?? 'Unknown opening'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-gray-500">Date</dt>
+              <dd className="text-white">{formatGameDate(game.created_at)}</dd>
+            </div>
+          </dl>
+
+          <div className="mb-4 flex flex-wrap items-start gap-4">
+            <div className="flex flex-col items-center gap-1">
+              <div style={{ height: BOARD_SIZE_PX }}>
+                <EvalBar
+                  scoreCp={currentScore.scoreCp}
+                  scoreMate={currentScore.scoreMate}
+                  orientation={orientation}
+                />
+              </div>
+              {/*
+               * EvalBar has no "no data" state of its own — a missing
+               * score would otherwise silently render as a fabricated
+               * neutral +0.0, contradicting EvalGraph's "No evaluation
+               * data" message for the exact same move. This caption makes
+               * that distinction visible without changing EvalBar's props
+               * (other pages render it unconditionally).
+               */}
+              {currentMoveIndex !== START_POSITION_INDEX && !currentMoveHasEval && (
+                <p data-testid="eval-bar-no-data" className="text-[10px] text-gray-500">
+                  No eval
+                </p>
+              )}
+            </div>
+
+            <Board position={boardFen} boardOrientation={orientation} boardWidth={BOARD_SIZE_PX} />
+
+            <div className="w-64 overflow-hidden" style={{ height: BOARD_SIZE_PX }}>
+              <MoveList
+                moves={moveItems}
+                currentMoveIndex={currentMoveIndex}
+                onMoveClick={setCurrentMoveIndex}
+              />
+            </div>
+          </div>
+
+          <nav aria-label="Move navigation" className="mb-4 flex flex-wrap gap-2">
+            <button type="button" onClick={goFirst} disabled={atStart} className={NAV_BUTTON_CLASS}>
+              First
+            </button>
+            <button type="button" onClick={goPrev} disabled={atStart} className={NAV_BUTTON_CLASS}>
+              Previous
+            </button>
+            <button type="button" onClick={goNext} disabled={atEnd} className={NAV_BUTTON_CLASS}>
+              Next
+            </button>
+            <button type="button" onClick={goLast} disabled={atEnd} className={NAV_BUTTON_CLASS}>
+              Last
+            </button>
+            <button
+              type="button"
+              onClick={() => setOrientation((o) => (o === 'white' ? 'black' : 'white'))}
+              aria-pressed={orientation === 'black'}
+              className={NAV_BUTTON_CLASS}
+            >
+              Flip Board
+            </button>
+          </nav>
+
+          <p role="status" aria-live="polite" className="mb-4 text-sm text-gray-400">
+            {atStart
+              ? 'Starting position'
+              : `${fullMoveLabel(currentMoveIndex)} ${moves[currentMoveIndex]?.san ?? ''} — move ${
+                  currentMoveIndex + 1
+                } of ${moves.length}`}
+          </p>
+
+          <div className="mb-4">
+            <h2 className="mb-1 text-lg font-semibold">Principal Variation</h2>
+            <p data-testid="pv-line" className="font-mono text-sm text-gray-300">
+              {currentPv.length > 0 ? currentPv.join(' ') : '—'}
+            </p>
+          </div>
+
+          <div>
+            <h2 className="mb-1 text-lg font-semibold">Evaluation</h2>
+            <EvalGraph points={graphPoints} currentMoveIndex={currentMoveIndex} />
+          </div>
+        </div>
+      )}
     </main>
   )
 }


### PR DESCRIPTION
Closes #49
Closes #10

`GameReplayPage` was a 7-line stub. It now loads a game by URL id and lets you step through it: view-only board, `EvalBar`, clickable `MoveList`, PV display, metadata header, board flip, and a new hand-rolled SVG `EvalGraph` plotting centipawn score across the whole game with the current move marked.

This is the last open sub-issue of umbrella #10, so the React Frontend epic closes too.

**No new dependency.** `frontend/package.json` is byte-identical to main — the chart is hand-rolled SVG, since frontend dependencies are exactly pinned by policy and the issue explicitly asked to avoid heavy deps.

## The bug all four review lenses independently found

Evaluations are stored **mover-relative**, so they must be converted to White's perspective for display. The first implementation inferred the mover from move-index parity (`index % 2 === 1`). That is wrong for any game starting from a Black-to-move position — and that is not hypothetical: SPRT games start from opening-book FENs, and any **odd-ply book line leaves Black to move**, which would invert *every* evaluation on the page for that whole class of games.

The first mover is now derived from `start_fen`'s active-colour field. Verified in a browser against a seeded book-start game: it renders `e5 (−3.0)`, `Nf3 (+1.5)`, `Nc6 (−2.5)`, `Bb5 (+1.2)`. The parity bug gave `+3.0` at index 0.

## Defensive details the null-heavy `Move` shape requires

Every numeric eval field on `Move` is `number | null`, which makes an SVG chart surprisingly easy to break:

- A move with no recorded eval contributes **no vertex**, so the line bridges the gap rather than emitting `NaN` into the path. A single `NaN` coordinate silently blanks the entire chart with no error, so the tests assert the exact `d` attribute and `cx` values, not just element counts.
- The eval bar is **captioned as having no data** instead of showing a fabricated `+0.0` — previously it contradicted the graph beside it, which correctly said "No evaluation data".
- `score_mate` is clamped into the graph's fixed cp domain using the **same sign boundary as `EvalBar`** (`> 0`, not `>= 0`), so the two components can never disagree at mate 0.
- Zero-move games, single-point graphs (`length - 1` is a classic `Infinity` source) and all-null-eval games render without dividing by zero.
- `created_at` is parsed with a fallback rather than string-sliced, and an **empty** error message no longer renders a completely blank page.

Move index `-1` means the starting position and `i` means "after `moves[i]`"; the convention is applied uniformly to board FEN, eval bar, PV, move-list highlight and graph highlight. Arrow keys reuse the same navigation callbacks as the buttons (rather than duplicating the clamp arithmetic) and are ignored while focus is in a form control.

## Verification

```
tsc --noEmit: clean    eslint: clean    prettier: clean    237 tests passed
```

Beyond jsdom, I ran the real app against two seeded games:

- **33-move game** — 32 of 33 moves plot (null-eval move skipped, mate clamped), no `NaN` in any path or coordinate, dynamic graph `aria-label`, current-move rule and marker both present, status line reads `10... cxb5 — move 20 of 33`.
- **Black-to-move book start** — eval signs correct, as above.
- Navigation, arrow keys, mate display (`M1`), flip (`aria-pressed` + `EvalBar` orientation follows), 404 (`role="alert"` → "Game not found."), and the no-id route (`games/:id?` is optional) all verified.

Umbrella #10's own acceptance list was checked too: `vite.config.ts` proxies `/api` and `/ws`, state is local + context with no store library, zero class components, zero default exports, explicit return types and exported props interfaces throughout.

`frontend/` only.

Note: `MoveList` pairs and numbers moves assuming even index = White, so a book-start game displays `1. e5 Nf3` rather than `1... e5 2. Nf3`. That component is untouched here (zero diff) and the issue is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)