### PR TITLE
fix: number moves from the starting position, not from index parity

### DIFF
--- a/frontend/src/components/MoveList/MoveList.test.tsx
+++ b/frontend/src/components/MoveList/MoveList.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { MoveList } from './MoveList'
 import type { MoveItem } from './MoveList'
+import { STANDARD_START_POSITION } from './startPosition'
+import type { StartPosition } from './startPosition'
 
 /** Generate a list of N dummy half-moves. */
 function makeMoves(count: number): MoveItem[] {
@@ -135,5 +137,132 @@ describe('MoveList', () => {
 
     expect(scrollIntoViewSpy).not.toHaveBeenCalled()
     scrollIntoViewSpy.mockRestore()
+  })
+
+  // -------------------------------------------------------------------------
+  // Non-standard starting positions (opening-book FENs)
+  // -------------------------------------------------------------------------
+
+  describe('with a Black-to-move starting position', () => {
+    // The position after 1. e4 — Black to move, still full-move 1 (a FEN's
+    // full-move counter increments only after Black has played). The game's
+    // recorded moves therefore begin with Black's reply.
+    const blackToMove: StartPosition = { blackToMove: true, fullMoveNumber: 1 }
+
+    // The Ruy Lopez continued from that position: the recorded moves are
+    // Black's e5, then White's Nf3, Black's Nc6, White's Bb5. Correct
+    // rendering is `1... e5`, `2. Nf3 Nc6`, `3. Bb5`.
+    const blackFirstMoves: MoveItem[] = [
+      { san: 'e5' },
+      { san: 'Nf3' },
+      { san: 'Nc6' },
+      { san: 'Bb5' },
+    ]
+
+    it('numbers the first Black move as "1..." rather than "1."', () => {
+      render(<MoveList moves={blackFirstMoves} currentMoveIndex={-1} startPosition={blackToMove} />)
+
+      expect(screen.getByText('1...')).toBeInTheDocument()
+      expect(screen.queryByText('1.')).not.toBeInTheDocument()
+    })
+
+    it('pairs every following move onto the correct full move', () => {
+      render(<MoveList moves={blackFirstMoves} currentMoveIndex={-1} startPosition={blackToMove} />)
+
+      expect(screen.getByText('2.')).toBeInTheDocument()
+      expect(screen.getByText('3.')).toBeInTheDocument()
+      // Three rows, exactly one of which is the leading Black-only row.
+      expect(screen.getAllByText(/^\d+\.$/)).toHaveLength(2)
+      expect(screen.getAllByText(/^\d+\.\.\.$/)).toHaveLength(1)
+    })
+
+    it('renders the leading Black move alone on its own row', () => {
+      render(<MoveList moves={blackFirstMoves} currentMoveIndex={-1} startPosition={blackToMove} />)
+
+      const firstRow = screen.getByText('1...').closest('div')
+      expect(firstRow).not.toBeNull()
+      const rowButtons = firstRow?.querySelectorAll('button') ?? []
+      expect(rowButtons).toHaveLength(1)
+      expect(rowButtons[0]).toHaveTextContent('e5')
+
+      // ...and the next row carries White's move followed by Black's.
+      const secondRow = screen.getByText('2.').closest('div')
+      const secondRowButtons = secondRow?.querySelectorAll('button') ?? []
+      expect(secondRowButtons).toHaveLength(2)
+      expect(secondRowButtons[0]).toHaveTextContent('Nf3')
+      expect(secondRowButtons[1]).toHaveTextContent('Nc6')
+    })
+
+    it('still highlights the move at currentMoveIndex', () => {
+      render(<MoveList moves={blackFirstMoves} currentMoveIndex={0} startPosition={blackToMove} />)
+
+      expect(screen.getByText('e5').closest('button')).toHaveClass('bg-blue-600')
+      expect(screen.getByText('Nf3').closest('button')).not.toHaveClass('bg-blue-600')
+    })
+
+    it('reports unshifted move indices to onMoveClick', async () => {
+      const user = userEvent.setup()
+      const onMoveClick = vi.fn()
+      render(
+        <MoveList
+          moves={blackFirstMoves}
+          currentMoveIndex={-1}
+          startPosition={blackToMove}
+          onMoveClick={onMoveClick}
+        />,
+      )
+
+      await user.click(screen.getByText('e5'))
+      expect(onMoveClick).toHaveBeenCalledWith(0)
+
+      await user.click(screen.getByText('Nf3'))
+      expect(onMoveClick).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('with a starting full-move number other than 1', () => {
+    it('numbers from the starting full move for a White-to-move start', () => {
+      render(
+        <MoveList
+          moves={sampleMoves}
+          currentMoveIndex={-1}
+          startPosition={{ blackToMove: false, fullMoveNumber: 12 }}
+        />,
+      )
+
+      expect(screen.getByText('12.')).toBeInTheDocument()
+      expect(screen.getByText('13.')).toBeInTheDocument()
+      expect(screen.getByText('14.')).toBeInTheDocument()
+      expect(screen.queryByText('1.')).not.toBeInTheDocument()
+    })
+
+    it('numbers from the starting full move for a Black-to-move start', () => {
+      render(
+        <MoveList
+          moves={sampleMoves}
+          currentMoveIndex={-1}
+          startPosition={{ blackToMove: true, fullMoveNumber: 12 }}
+        />,
+      )
+
+      expect(screen.getByText('12...')).toBeInTheDocument()
+      expect(screen.getByText('13.')).toBeInTheDocument()
+      expect(screen.getByText('14.')).toBeInTheDocument()
+    })
+  })
+
+  it('defaults to the standard start when no startPosition is given', () => {
+    const { unmount } = render(<MoveList moves={sampleMoves} currentMoveIndex={-1} />)
+    const implicit = screen.getAllByText(/^\d+\.$/).map((el) => el.textContent)
+    unmount()
+
+    render(
+      <MoveList
+        moves={sampleMoves}
+        currentMoveIndex={-1}
+        startPosition={STANDARD_START_POSITION}
+      />,
+    )
+    expect(screen.getAllByText(/^\d+\.$/).map((el) => el.textContent)).toEqual(implicit)
   })
 })

--- a/frontend/src/components/MoveList/MoveList.tsx
+++ b/frontend/src/components/MoveList/MoveList.tsx
@@ -1,4 +1,10 @@
 import { useEffect, useRef } from 'react'
+import {
+  STANDARD_START_POSITION,
+  fullMoveNumberAt,
+  isBlackMoveAt,
+  type StartPosition,
+} from './startPosition'
 
 export interface MoveItem {
   san: string
@@ -8,27 +14,45 @@ export interface MoveItem {
 export interface MoveListProps {
   moves: MoveItem[]
   currentMoveIndex: number
+  /**
+   * Position `moves[0]` was played from. Defaults to the standard initial
+   * position, which is what a game started from scratch uses.
+   */
+  startPosition?: StartPosition
   onMoveClick?: (index: number) => void
 }
 
-interface MovePair {
-  moveNumber: number
-  white: { san: string; annotation?: string; index: number }
-  black?: { san: string; annotation?: string; index: number }
+interface MoveCell {
+  san: string
+  annotation?: string
+  index: number
 }
 
-function groupMoves(moves: MoveItem[]): MovePair[] {
-  const pairs: MovePair[] = []
-  for (let i = 0; i < moves.length; i += 2) {
-    const white = moves[i]
-    const black = moves[i + 1]
-    pairs.push({
-      moveNumber: Math.floor(i / 2) + 1,
-      white: { san: white.san, annotation: white.annotation, index: i },
-      black: black ? { san: black.san, annotation: black.annotation, index: i + 1 } : undefined,
-    })
-  }
-  return pairs
+interface MoveRow {
+  moveNumber: number
+  white?: MoveCell
+  black?: MoveCell
+}
+
+/**
+ * Group half-moves into one row per full move. Only the first row can lack a
+ * White move — that is the Black-to-move start — since every later full move
+ * begins with White by definition.
+ */
+function groupMoves(moves: MoveItem[], start: StartPosition): MoveRow[] {
+  const rows: MoveRow[] = []
+  moves.forEach((move, index) => {
+    const cell: MoveCell = { san: move.san, annotation: move.annotation, index }
+    const moveNumber = fullMoveNumberAt(index, start)
+    if (!isBlackMoveAt(index, start)) {
+      rows.push({ moveNumber, white: cell })
+      return
+    }
+    const openRow = rows[rows.length - 1]
+    if (openRow?.moveNumber === moveNumber) openRow.black = cell
+    else rows.push({ moveNumber, black: cell })
+  })
+  return rows
 }
 
 /** Threshold in pixels — auto-scroll only when within this distance of the bottom. */
@@ -37,6 +61,7 @@ const SCROLL_THRESHOLD = 50
 export function MoveList({
   moves,
   currentMoveIndex,
+  startPosition = STANDARD_START_POSITION,
   onMoveClick,
 }: MoveListProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -62,25 +87,35 @@ export function MoveList({
     return <div className="p-4 text-gray-400">No moves</div>
   }
 
-  const pairs = groupMoves(moves)
+  const rows = groupMoves(moves, startPosition)
 
   return (
     <div ref={containerRef} className="h-full overflow-y-auto rounded bg-gray-800 p-2 text-sm">
-      {pairs.map((pair) => (
-        <div key={pair.moveNumber} className="flex items-baseline gap-1 py-0.5">
-          <span className="w-8 shrink-0 text-right text-gray-500">{pair.moveNumber}.</span>
-          <MoveButton
-            san={pair.white.san}
-            annotation={pair.white.annotation}
-            isActive={pair.white.index === currentMoveIndex}
-            onClick={() => onMoveClick?.(pair.white.index)}
-          />
-          {pair.black && (
+      {rows.map(({ moveNumber, white, black }) => (
+        <div key={moveNumber} className="flex items-baseline gap-1 py-0.5">
+          {/*
+           * `min-w-8` rather than a fixed width: a leading Black-only row is
+           * labelled `12...`, which is wider than the `12.` the column was
+           * sized for. Standard games are unaffected — their labels all fit
+           * the same 2rem minimum.
+           */}
+          <span className="min-w-8 shrink-0 whitespace-nowrap text-right text-gray-500">
+            {white ? `${moveNumber}.` : `${moveNumber}...`}
+          </span>
+          {white && (
             <MoveButton
-              san={pair.black.san}
-              annotation={pair.black.annotation}
-              isActive={pair.black.index === currentMoveIndex}
-              onClick={() => onMoveClick?.(pair.black.index)}
+              san={white.san}
+              annotation={white.annotation}
+              isActive={white.index === currentMoveIndex}
+              onClick={() => onMoveClick?.(white.index)}
+            />
+          )}
+          {black && (
+            <MoveButton
+              san={black.san}
+              annotation={black.annotation}
+              isActive={black.index === currentMoveIndex}
+              onClick={() => onMoveClick?.(black.index)}
             />
           )}
         </div>

--- a/frontend/src/components/MoveList/startPosition.test.ts
+++ b/frontend/src/components/MoveList/startPosition.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  STANDARD_START_POSITION,
+  fullMoveNumberAt,
+  isBlackMoveAt,
+  moveLabel,
+  parseStartPosition,
+} from './startPosition'
+import type { StartPosition } from './startPosition'
+
+describe('parseStartPosition', () => {
+  it('reads the standard initial position as White to move at full move 1', () => {
+    expect(parseStartPosition('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1')).toEqual(
+      STANDARD_START_POSITION,
+    )
+  })
+
+  it('reads the active colour and full move from an opening-book FEN', () => {
+    // Position after 1. e4 — Black to move, full move still 1 (the counter
+    // increments only once Black has replied).
+    expect(
+      parseStartPosition('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'),
+    ).toEqual({ blackToMove: true, fullMoveNumber: 1 })
+  })
+
+  it('reads a mid-game full-move number', () => {
+    expect(parseStartPosition('8/8/8/8/8/8/8/K6k b - - 4 27')).toEqual({
+      blackToMove: true,
+      fullMoveNumber: 27,
+    })
+  })
+
+  it('falls back to the standard start for a null or malformed FEN', () => {
+    expect(parseStartPosition(null)).toEqual(STANDARD_START_POSITION)
+    expect(parseStartPosition(undefined)).toEqual(STANDARD_START_POSITION)
+    expect(parseStartPosition('')).toEqual(STANDARD_START_POSITION)
+    expect(parseStartPosition('not a fen')).toEqual(STANDARD_START_POSITION)
+  })
+
+  it('falls back to full move 1 when the full-move field is not a positive integer', () => {
+    expect(parseStartPosition('8/8/8/8/8/8/8/K6k w - - 0 0').fullMoveNumber).toBe(1)
+    expect(parseStartPosition('8/8/8/8/8/8/8/K6k w - - 0 -3').fullMoveNumber).toBe(1)
+    expect(parseStartPosition('8/8/8/8/8/8/8/K6k w - - 0 x').fullMoveNumber).toBe(1)
+    expect(parseStartPosition('8/8/8/8/8/8/8/K6k w - - 0 2.5').fullMoveNumber).toBe(1)
+  })
+
+  it('tolerates irregular whitespace between FEN fields', () => {
+    expect(parseStartPosition('  8/8/8/8/8/8/8/K6k   b  -  -  4  27  ')).toEqual({
+      blackToMove: true,
+      fullMoveNumber: 27,
+    })
+  })
+})
+
+describe('isBlackMoveAt', () => {
+  it('alternates from White for a standard start', () => {
+    expect(isBlackMoveAt(0, STANDARD_START_POSITION)).toBe(false)
+    expect(isBlackMoveAt(1, STANDARD_START_POSITION)).toBe(true)
+    expect(isBlackMoveAt(2, STANDARD_START_POSITION)).toBe(false)
+  })
+
+  it('alternates from Black for a Black-to-move start', () => {
+    const start: StartPosition = { blackToMove: true, fullMoveNumber: 1 }
+    expect(isBlackMoveAt(0, start)).toBe(true)
+    expect(isBlackMoveAt(1, start)).toBe(false)
+    expect(isBlackMoveAt(2, start)).toBe(true)
+  })
+})
+
+describe('fullMoveNumberAt', () => {
+  it('advances after every Black move from a standard start', () => {
+    expect(fullMoveNumberAt(0, STANDARD_START_POSITION)).toBe(1)
+    expect(fullMoveNumberAt(1, STANDARD_START_POSITION)).toBe(1)
+    expect(fullMoveNumberAt(2, STANDARD_START_POSITION)).toBe(2)
+  })
+
+  it('advances immediately after the leading Black move of a Black-to-move start', () => {
+    const start: StartPosition = { blackToMove: true, fullMoveNumber: 1 }
+    expect(fullMoveNumberAt(0, start)).toBe(1)
+    expect(fullMoveNumberAt(1, start)).toBe(2)
+    expect(fullMoveNumberAt(2, start)).toBe(2)
+  })
+
+  it('counts up from the starting full move', () => {
+    const start: StartPosition = { blackToMove: false, fullMoveNumber: 12 }
+    expect(fullMoveNumberAt(0, start)).toBe(12)
+    expect(fullMoveNumberAt(2, start)).toBe(13)
+  })
+})
+
+describe('moveLabel', () => {
+  it('labels White moves "N." and Black moves "N..." from a standard start', () => {
+    expect(moveLabel(0, STANDARD_START_POSITION)).toBe('1.')
+    expect(moveLabel(1, STANDARD_START_POSITION)).toBe('1...')
+    expect(moveLabel(4, STANDARD_START_POSITION)).toBe('3.')
+  })
+
+  it('offsets by the starting side and full move', () => {
+    const start: StartPosition = { blackToMove: true, fullMoveNumber: 12 }
+    expect(moveLabel(0, start)).toBe('12...')
+    expect(moveLabel(1, start)).toBe('13.')
+    expect(moveLabel(2, start)).toBe('13...')
+  })
+})

--- a/frontend/src/components/MoveList/startPosition.ts
+++ b/frontend/src/components/MoveList/startPosition.ts
@@ -1,0 +1,75 @@
+/**
+ * Move numbering for games that do not begin at the standard initial
+ * position.
+ *
+ * Lives beside MoveList rather than inside it because more than the list
+ * needs it: the replay page names a single move in its status line and picks
+ * the eval sign per move from the same derivation. Keeping one source of
+ * truth is what stops those displays disagreeing with each other.
+ */
+
+/**
+ * The position a game's recorded moves begin from, in the two respects that
+ * decide how those moves are numbered.
+ *
+ * Neither field can be assumed: SPRT games are seeded from opening books,
+ * which supply arbitrary FENs — an odd-ply book line leaves *Black* to move,
+ * and a line resumed mid-game starts at a full-move number above 1. Deriving
+ * the numbering from move-index parity instead renders Black's move in
+ * White's column and shifts every move number for the rest of the game.
+ */
+export interface StartPosition {
+  /** True when Black is the side to move in the starting position. */
+  blackToMove: boolean
+  /** The starting position's FEN full-move counter (1 for a new game). */
+  fullMoveNumber: number
+}
+
+/** The standard initial position: White to move, full move 1. */
+export const STANDARD_START_POSITION: StartPosition = {
+  blackToMove: false,
+  fullMoveNumber: 1,
+}
+
+/**
+ * Read the numbering-relevant fields out of a FEN — the active-colour field
+ * and the full-move counter. A null, empty or malformed FEN falls back to
+ * {@link STANDARD_START_POSITION}; `GameDetail.start_fen` is null for games
+ * played from the standard position, so that fallback is the common path,
+ * not just an error case.
+ */
+export function parseStartPosition(fen: string | null | undefined): StartPosition {
+  const fields = fen?.trim().split(/\s+/) ?? []
+  const fullMoveNumber = Number(fields[5])
+  return {
+    blackToMove: fields[1] === 'b',
+    fullMoveNumber: Number.isInteger(fullMoveNumber) && fullMoveNumber >= 1 ? fullMoveNumber : 1,
+  }
+}
+
+/**
+ * Ply offset of `index` within its full move: 0 for a White move, 1 for a
+ * Black one. Moves alternate colour strictly from the side to move in
+ * `start`, so this is index parity shifted by who moves first.
+ */
+function plyOf(index: number, start: StartPosition): number {
+  return index + (start.blackToMove ? 1 : 0)
+}
+
+/** True when the move at `index` was played by Black. */
+export function isBlackMoveAt(index: number, start: StartPosition): boolean {
+  return plyOf(index, start) % 2 === 1
+}
+
+/** The full-move number the move at `index` belongs to. */
+export function fullMoveNumberAt(index: number, start: StartPosition): number {
+  return start.fullMoveNumber + Math.floor(plyOf(index, start) / 2)
+}
+
+/**
+ * Algebraic label for a single move — `12.` for White's, `12...` for
+ * Black's.
+ */
+export function moveLabel(index: number, start: StartPosition): string {
+  return `${fullMoveNumberAt(index, start)}${isBlackMoveAt(index, start) ? '...' : '.'}`
+}

--- a/frontend/src/pages/GameReplayPage.test.tsx
+++ b/frontend/src/pages/GameReplayPage.test.tsx
@@ -581,4 +581,51 @@ describe('GameReplayPage', () => {
     expect(screen.getByText('−3.0')).toBeInTheDocument()
     expect(screen.queryByText('+3.0')).not.toBeInTheDocument()
   })
+
+  // -----------------------------------------------------------------------
+  // Move numbering: also derived from start_fen, shared with MoveList
+  // -----------------------------------------------------------------------
+
+  it('numbers the status line from start_fen when Black moves first', async () => {
+    // Position after 1. e4: Black to move, still full move 1.
+    const blackToMoveStartFen = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
+    vi.mocked(fetchGame).mockResolvedValue({ ...sampleGame, start_fen: blackToMoveStartFen })
+    const user = userEvent.setup()
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    // moves[0] is Black's reply, so it is "1...", not "1.".
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    expect(screen.getByRole('status')).toHaveTextContent('1...')
+    expect(screen.getByRole('status')).toHaveTextContent('move 1 of 5')
+
+    // moves[1] is White's, opening full move 2.
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    expect(screen.getByRole('status')).toHaveTextContent('2.')
+  })
+
+  it('numbers the move list from start_fen when Black moves first', async () => {
+    const blackToMoveStartFen = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
+    vi.mocked(fetchGame).mockResolvedValue({ ...sampleGame, start_fen: blackToMoveStartFen })
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    // 5 half-moves from a Black-to-move start: 1... / 2. / 3. — never "1.".
+    expect(screen.getByText('1...')).toBeInTheDocument()
+    expect(screen.queryByText('1.')).not.toBeInTheDocument()
+    expect(screen.getByText('2.')).toBeInTheDocument()
+    expect(screen.getByText('3.')).toBeInTheDocument()
+  })
+
+  it('numbers from the start_fen full-move counter, not from 1', async () => {
+    // A book line resumed at full move 12, White to move.
+    const midGameStartFen = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 12'
+    vi.mocked(fetchGame).mockResolvedValue({ ...sampleGame, start_fen: midGameStartFen })
+    renderAtPath('/games/game-1')
+    await waitFor(() => expect(screen.getByTestId('chessboard')).toBeInTheDocument())
+
+    expect(screen.getByText('12.')).toBeInTheDocument()
+    expect(screen.getByText('14.')).toBeInTheDocument()
+    expect(screen.queryByText('1.')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/GameReplayPage.tsx
+++ b/frontend/src/pages/GameReplayPage.tsx
@@ -6,6 +6,8 @@ import { Board } from '../components/Board/Board'
 import { EvalBar } from '../components/EvalBar/EvalBar'
 import { MoveList } from '../components/MoveList/MoveList'
 import type { MoveItem } from '../components/MoveList/MoveList'
+import { isBlackMoveAt, moveLabel, parseStartPosition } from '../components/MoveList/startPosition'
+import type { StartPosition } from '../components/MoveList/startPosition'
 import { EvalGraph } from '../components/EvalGraph/EvalGraph'
 import type { EvalGraphPoint } from '../components/EvalGraph/EvalGraph'
 
@@ -32,24 +34,14 @@ interface WhitePerspectiveScore {
 }
 
 /**
- * True when the side to move in `fen`'s active-colour field is Black.
- * Defaults to White (`false`) for a null/malformed FEN — the standard
- * initial position always has White to move.
- */
-function isBlackToMove(fen: string | null): boolean {
-  return (fen?.split(' ')[1] ?? 'w') === 'b'
-}
-
-/**
  * Eval sign convention: `Move.score_cp` / `Move.score_mate` are stored from
  * the perspective of whichever side made that move (the raw UCI `info
- * score` convention). Moves strictly alternate colour starting from
- * whoever is to move in `start_fen`, so the mover of `moves[index]` is
- * White iff `(index % 2 === 1) !== firstMoverIsBlack` is false — i.e. we
- * cannot assume index 0 is White's move, because `start_fen` (arbitrary
- * opening-book positions, including odd-ply lines) may have Black to move
- * first. `firstMoverIsBlack` must come from the active-colour field of
- * `game.start_fen` (via {@link isBlackToMove}), not be assumed.
+ * score` convention). Moves strictly alternate colour starting from whoever
+ * is to move in `start_fen`, so index 0 cannot be assumed to be White's —
+ * `start_fen` holds arbitrary opening-book positions, including odd-ply
+ * lines with Black to move. The mover therefore comes from
+ * {@link isBlackMoveAt} against the parsed `start_fen`, which is the same
+ * derivation MoveList uses to number the moves.
  *
  * EvalBar and EvalGraph both read scores as "White's advantage" (the
  * conventional way to read an eval bar/graph), so a move played by Black
@@ -58,9 +50,9 @@ function isBlackToMove(fen: string | null): boolean {
 function toWhitePerspective(
   move: Move,
   index: number,
-  firstMoverIsBlack: boolean,
+  startPosition: StartPosition,
 ): WhitePerspectiveScore {
-  const isBlackMove = (index % 2 === 1) !== firstMoverIsBlack
+  const isBlackMove = isBlackMoveAt(index, startPosition)
   const scoreCp = move.score_cp === null ? undefined : isBlackMove ? -move.score_cp : move.score_cp
   const scoreMate =
     move.score_mate === null ? undefined : isBlackMove ? -move.score_mate : move.score_mate
@@ -80,20 +72,6 @@ function formatAnnotation(score: WhitePerspectiveScore): string | undefined {
     return `(−${Math.abs(pawns).toFixed(1)})`
   }
   return undefined
-}
-
-/**
- * Full-move + side label for the status line, e.g. `3.` for a White move
- * or `3...` for a Black move — matching MoveList's own (pre-existing,
- * out-of-scope-here) even-index-is-White pairing convention, so the two
- * displays never disagree with each other even though that shared
- * convention is itself wrong for a Black-to-move `start_fen` (see
- * `toWhitePerspective` above for the eval-sign fix; MoveList's grouping is
- * a separate, pre-existing component this page does not modify).
- */
-function fullMoveLabel(index: number): string {
-  const moveNumber = Math.floor(index / 2) + 1
-  return index % 2 === 0 ? `${moveNumber}.` : `${moveNumber}...`
 }
 
 /**
@@ -233,15 +211,17 @@ function GameReplayView({ id }: GameReplayViewProps): React.JSX.Element {
       ? (game?.start_fen ?? STANDARD_INITIAL_FEN)
       : (moves[currentMoveIndex]?.fen_after ?? STANDARD_INITIAL_FEN)
 
-  // Who moves first is read from `start_fen`'s active-colour field, not
-  // assumed to be White — an opening-book position can have Black to move.
-  // See `toWhitePerspective`'s doc comment.
-  const firstMoverIsBlack = isBlackToMove(game?.start_fen ?? null)
+  // Who moves first, and which full move the game resumes at, are read from
+  // `start_fen` rather than assumed — an opening-book position can have
+  // Black to move and can start well past move 1. This single parse feeds
+  // both the eval signs (`toWhitePerspective`) and the move numbering
+  // (MoveList, and the status line below).
+  const startPosition = parseStartPosition(game?.start_fen)
 
   const currentScore: WhitePerspectiveScore =
     currentMoveIndex === START_POSITION_INDEX || !moves[currentMoveIndex]
       ? {}
-      : toWhitePerspective(moves[currentMoveIndex], currentMoveIndex, firstMoverIsBlack)
+      : toWhitePerspective(moves[currentMoveIndex], currentMoveIndex, startPosition)
 
   const currentMoveHasEval =
     currentMoveIndex !== START_POSITION_INDEX &&
@@ -252,11 +232,11 @@ function GameReplayView({ id }: GameReplayViewProps): React.JSX.Element {
 
   const moveItems: MoveItem[] = moves.map((m, i) => ({
     san: m.san,
-    annotation: formatAnnotation(toWhitePerspective(m, i, firstMoverIsBlack)),
+    annotation: formatAnnotation(toWhitePerspective(m, i, startPosition)),
   }))
 
   const graphPoints: EvalGraphPoint[] = moves.map((m, i) => {
-    const score = toWhitePerspective(m, i, firstMoverIsBlack)
+    const score = toWhitePerspective(m, i, startPosition)
     return {
       scoreCp: score.scoreCp ?? null,
       scoreMate: score.scoreMate ?? null,
@@ -339,6 +319,7 @@ function GameReplayView({ id }: GameReplayViewProps): React.JSX.Element {
               <MoveList
                 moves={moveItems}
                 currentMoveIndex={currentMoveIndex}
+                startPosition={startPosition}
                 onMoveClick={setCurrentMoveIndex}
               />
             </div>
@@ -370,7 +351,7 @@ function GameReplayView({ id }: GameReplayViewProps): React.JSX.Element {
           <p role="status" aria-live="polite" className="mb-4 text-sm text-gray-400">
             {atStart
               ? 'Starting position'
-              : `${fullMoveLabel(currentMoveIndex)} ${moves[currentMoveIndex]?.san ?? ''} — move ${
+              : `${moveLabel(currentMoveIndex, startPosition)} ${moves[currentMoveIndex]?.san ?? ''} — move ${
                   currentMoveIndex + 1
                 } of ${moves.length}`}
           </p>

--- a/frontend/src/pages/SPRTTestsPage.test.tsx
+++ b/frontend/src/pages/SPRTTestsPage.test.tsx
@@ -293,6 +293,40 @@ describe('SPRTTestsPage', () => {
     })
   })
 
+  // The backend caps concurrency at 64 (`ge=1, le=64` on
+  // SPRTTestCreateRequest); rejecting it client-side keeps the user out of a
+  // round-trip that can only come back as a 422.
+  it('shows validation error when concurrency exceeds the backend cap', async () => {
+    render(<SPRTTestsPage />)
+    await waitFor(() => expect(screen.getByText('New Test')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('New Test'))
+    await userEvent.selectOptions(screen.getByLabelText('Engine A'), 'engine-1')
+    await userEvent.selectOptions(screen.getByLabelText('Engine B'), 'engine-2')
+
+    const concurrencyInput = screen.getByLabelText('Concurrency')
+    await userEvent.clear(concurrencyInput)
+    await userEvent.type(concurrencyInput, '65')
+
+    await userEvent.click(screen.getByText('Create Test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Concurrency must be between 1 and 64')).toBeInTheDocument()
+    })
+    expect(createSPRTTest).not.toHaveBeenCalled()
+  })
+
+  it('constrains the concurrency input to the backend range', async () => {
+    render(<SPRTTestsPage />)
+    await waitFor(() => expect(screen.getByText('New Test')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('New Test'))
+
+    const concurrencyInput = screen.getByLabelText('Concurrency')
+    expect(concurrencyInput).toHaveAttribute('min', '1')
+    expect(concurrencyInput).toHaveAttribute('max', '64')
+  })
+
   // -----------------------------------------------------------------------
   // Form submission
   // -----------------------------------------------------------------------

--- a/frontend/src/pages/SPRTTestsPage.tsx
+++ b/frontend/src/pages/SPRTTestsPage.tsx
@@ -72,7 +72,16 @@ interface FormErrors {
   elo?: string
   alpha?: string
   beta?: string
+  concurrency?: string
 }
+
+/**
+ * Worker-count bounds, mirroring `SPRTTestCreateRequest.concurrency`
+ * (`ge=1, le=64`) on the backend. Kept in step with it so an out-of-range
+ * value is named here rather than coming back as a 422.
+ */
+const MIN_CONCURRENCY = 1
+const MAX_CONCURRENCY = 64
 
 function validateForm(
   engineA: string,
@@ -82,6 +91,7 @@ function validateForm(
   elo1: number,
   alpha: number,
   beta: number,
+  concurrency: number,
 ): FormErrors {
   const errors: FormErrors = {}
   if (!engineA) errors.engineA = 'Engine A is required'
@@ -90,6 +100,13 @@ function validateForm(
   if (elo1 <= elo0) errors.elo = 'Elo1 must be greater than Elo0'
   if (alpha <= 0 || alpha >= 1) errors.alpha = 'Alpha must be between 0 and 1'
   if (beta <= 0 || beta >= 1) errors.beta = 'Beta must be between 0 and 1'
+  if (
+    !Number.isInteger(concurrency) ||
+    concurrency < MIN_CONCURRENCY ||
+    concurrency > MAX_CONCURRENCY
+  ) {
+    errors.concurrency = `Concurrency must be between ${MIN_CONCURRENCY} and ${MAX_CONCURRENCY}`
+  }
   return errors
 }
 
@@ -280,7 +297,7 @@ export function SPRTTestsPage(): React.JSX.Element {
   )
 
   const handleSubmit = useCallback(async (): Promise<void> => {
-    const errors = validateForm(engineA, engineB, timeControl, elo0, elo1, alpha, beta)
+    const errors = validateForm(engineA, engineB, timeControl, elo0, elo1, alpha, beta, concurrency)
     setFormErrors(errors)
     if (Object.keys(errors).length > 0) return
 
@@ -594,11 +611,15 @@ export function SPRTTestsPage(): React.JSX.Element {
               <input
                 id="concurrency"
                 type="number"
-                min="1"
+                min={MIN_CONCURRENCY}
+                max={MAX_CONCURRENCY}
                 className="w-full rounded bg-gray-700 px-3 py-2 text-white"
                 value={concurrency}
                 onChange={(e) => setConcurrency(Number(e.target.value))}
               />
+              {formErrors.concurrency && (
+                <p className="mt-1 text-xs text-red-400">{formErrors.concurrency}</p>
+              )}
               <HelpText>
                 Number of games to play in parallel. Each worker runs one game at a time.
               </HelpText>

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -360,4 +360,88 @@ describe('ApiError handling', () => {
       expect((e as ApiError).message).toBe('Service Unavailable')
     }
   })
+
+  // FastAPI renders a 422 as `detail: [{loc, msg, type}, ...]`, not a string.
+  // Stringifying that array naively yields "[object Object]", which tells the
+  // user nothing about which field the backend rejected.
+  describe('422 validation detail arrays', () => {
+    /** Build a non-ok Response whose JSON body is `{ detail }`. */
+    function validationResponse(detail: unknown): Response {
+      return {
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        json: () => Promise.resolve({ detail }),
+      } as unknown as Response
+    }
+
+    async function messageFor(detail: unknown): Promise<string> {
+      mockFetch.mockResolvedValueOnce(validationResponse(detail))
+      try {
+        await fetchEngines()
+        expect.fail('Should have thrown')
+      } catch (e) {
+        expect(e).toBeInstanceOf(ApiError)
+        return (e as ApiError).message
+      }
+    }
+
+    it('names the rejected field and its message', async () => {
+      const message = await messageFor([
+        {
+          type: 'less_than_equal',
+          loc: ['body', 'concurrency'],
+          msg: 'Input should be less than or equal to 64',
+        },
+      ])
+
+      expect(message).toBe('concurrency: Input should be less than or equal to 64')
+      expect(message).not.toContain('[object Object]')
+    })
+
+    it('joins multiple validation errors', async () => {
+      const message = await messageFor([
+        { type: 'greater_than', loc: ['body', 'alpha'], msg: 'Input should be greater than 0' },
+        { type: 'missing', loc: ['body', 'engine_a'], msg: 'Field required' },
+      ])
+
+      expect(message).toBe('alpha: Input should be greater than 0; engine_a: Field required')
+    })
+
+    it('joins a nested location with dots and drops the request-part prefix', async () => {
+      const message = await messageFor([
+        {
+          type: 'string_type',
+          loc: ['body', 'time_control', 'type'],
+          msg: 'Input should be a string',
+        },
+      ])
+
+      expect(message).toBe('time_control.type: Input should be a string')
+    })
+
+    it('falls back to the message alone when there is no usable location', async () => {
+      expect(
+        await messageFor([{ type: 'value_error', loc: [], msg: 'Elo1 must exceed Elo0' }]),
+      ).toBe('Elo1 must exceed Elo0')
+      expect(await messageFor([{ type: 'value_error', msg: 'Elo1 must exceed Elo0' }])).toBe(
+        'Elo1 must exceed Elo0',
+      )
+    })
+
+    it('renders a plain string detail unchanged', async () => {
+      expect(await messageFor('Engine not found')).toBe('Engine not found')
+    })
+
+    it('renders an array of plain strings', async () => {
+      expect(await messageFor(['first problem', 'second problem'])).toBe(
+        'first problem; second problem',
+      )
+    })
+
+    it('falls back to statusText for an empty or unusable detail array', async () => {
+      expect(await messageFor([])).toBe('Unprocessable Entity')
+      expect(await messageFor([{ type: 'value_error' }])).toBe('Unprocessable Entity')
+    })
+  })
 })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -44,16 +44,64 @@ export class ApiError extends Error {
 }
 
 /**
+ * Request parts FastAPI prefixes a validation `loc` with. They say where the
+ * value came from, not which field failed, so they are dropped from the
+ * user-facing message: `['body', 'concurrency']` reads as `concurrency`.
+ */
+const REQUEST_PARTS = new Set(['body', 'query', 'path', 'header', 'cookie'])
+
+/**
+ * Render one entry of a FastAPI validation-error array as `field: message`.
+ * Returns an empty string for anything without a usable `msg`, so the caller
+ * can fall back rather than surfacing a fragment of nothing.
+ */
+function formatValidationError(entry: unknown): string {
+  if (typeof entry === 'string') return entry
+  if (typeof entry !== 'object' || entry === null) return ''
+
+  const { loc, msg } = entry as { loc?: unknown; msg?: unknown }
+  if (typeof msg !== 'string' || msg === '') return ''
+
+  const path = Array.isArray(loc)
+    ? loc
+        .filter((part, i) => !(i === 0 && typeof part === 'string' && REQUEST_PARTS.has(part)))
+        .join('.')
+    : ''
+  return path ? `${path}: ${msg}` : msg
+}
+
+/**
+ * Turn a response body's `detail` into a message worth showing.
+ *
+ * A 422 from FastAPI carries an *array* of `{loc, msg, type}` objects rather
+ * than a string; stringifying that naively yields "[object Object]", which
+ * hides which field the backend actually rejected. Returns an empty string
+ * when nothing usable can be extracted, leaving the caller to fall back to
+ * the HTTP status text.
+ */
+function formatDetail(detail: unknown): string {
+  if (typeof detail === 'string') return detail
+  if (Array.isArray(detail)) {
+    return detail.map(formatValidationError).filter(Boolean).join('; ')
+  }
+  // Preserve the previous stringify for primitives; an object detail has no
+  // useful string form, so let the caller fall back instead.
+  if (typeof detail === 'number' || typeof detail === 'boolean') return String(detail)
+  return ''
+}
+
+/**
  * Parse a non-ok response and throw an {@link ApiError}.
  */
 async function handleError(response: Response): Promise<never> {
   let message: string
   try {
     const body: unknown = await response.json()
-    message =
+    const detail =
       typeof body === 'object' && body !== null && 'detail' in body
-        ? String((body as { detail: unknown }).detail)
-        : response.statusText
+        ? (body as { detail: unknown }).detail
+        : undefined
+    message = formatDetail(detail) || response.statusText
   } catch {
     message = response.statusText
   }


### PR DESCRIPTION
Closes #175.

## The bug

`MoveList` assumed every game begins with White at full move 1: `groupMoves()` paired `moves[i]` with `moves[i + 1]` from even `i` and labelled each pair `Math.floor(i / 2) + 1`.

SPRT games are seeded from opening books, and those FENs can leave **Black** to move (any odd-ply book line) and can resume well past move 1. For such a game the old code put Black's move in White's column and shifted every move number for the rest of the game:

| | before | after |
|---|---|---|
| game starting after `1. e4` | `1. e5 Nf3` / `2. Nc6 Bb5` | `1... e5` / `2. Nf3 Nc6` / `3. Bb5` |
| book line resumed at move 12 | `1. h3 h6` / `2. Re1 Re8` | `12. h3 h6` / `13. Re1 Re8` |
| standard start | `1. e4 e5` … | unchanged |

## The fix

Numbering now derives from the starting position's active colour **and** full-move counter, parsed from `start_fen`.

That derivation lives in one new module, `frontend/src/components/MoveList/startPosition.ts`, because three displays depend on it and had been drifting apart:

- `MoveList` groups half-moves into one row per full move — only the first row can lack a White move, which is exactly the Black-to-move start.
- `GameReplayPage`'s status line labels a single move (`2... Nc6`) from the same helper instead of its own copy.
- The eval signs on that page pick the mover from the same helper too.

#174 had already fixed the eval signs against `start_fen` this way, but deliberately left `MoveList` on the old convention as out of scope, leaving two contradictory derivations in one page. Both local helpers (`isBlackToMove`, `fullMoveLabel`) are deleted in favour of the shared module, so this is one source of truth rather than a third copy.

The move-number column moves from `w-8` to `min-w-8` so a `12...` label fits; standard games are visually unchanged.

## Folded in: FastAPI 422 bodies rendered as `[object Object]`

Pre-existing, but #171's new request validation made it much easier to hit, so it is fixed here rather than filed separately.

`handleError` in `frontend/src/services/api.ts` did `String(body.detail)`. That is fine for a string detail, but a 422 carries an **array** of `{loc, msg, type}` objects, which stringified to `[object Object]` and hid which field the backend rejected. It now reads:

```
elo0: Input should be less than or equal to 1000; elo1: Input should be less than or equal to 1000
```

The `body`/`query`/`path` prefix is dropped from `loc` as noise, nested locations join with dots, and anything without a usable `msg` falls back to the HTTP status text as before. The SPRT form also gained the client-side concurrency bound matching the backend's `ge=1, le=64`, so the most likely way to hit that 422 is now caught before the round trip.

## Verification

TDD: 23 tests written red first, then made green. The new tests were mutation-checked — dropping the side offset in `plyOf` kills 10 of them, hardcoding the base full move to 1 kills 5 — so they fail for the right reason rather than passing by construction.

Gates: 270 tests pass, `tsc --noEmit`, `eslint src/`, `prettier --check src/` all clean.

Checked in a real browser (backend + Vite from `.claude/launch.json`) against three seeded games — Black-to-move start, a book line at full move 12, and a standard game as the regression baseline. The "before" column in the table above is measured, not assumed: the same page was re-rendered with this branch stashed to capture main's output.

## Note, not introduced here

`react-chessboard` throws `Square width not found` and takes the React tree down whenever the board's position changes in a zero-size viewport. This reproduces identically on `main` and does not affect a normally-sized browser; it only shows up when driving the app headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)