### PR TITLE
feat: expose --syzygy-path on the SPRT runner CLI

### DIFF
--- a/sprt-runner/src/sprt_runner/adjudication.py
+++ b/sprt-runner/src/sprt_runner/adjudication.py
@@ -64,6 +64,57 @@ class AdjudicationConfig:
     syzygy_path: Path | None = None
 
 
+def validate_syzygy_path(raw_path: str) -> Path:
+    """Validate an explicitly-supplied Syzygy tablebase path at startup.
+
+    An unusable ``--syzygy-path`` must fail fast, before any game runs,
+    rather than silently disabling tablebase adjudication: opening an
+    empty or wrong-nesting-level directory succeeds and every probe then
+    returns nothing for the entire (potentially multi-hour) run.
+
+    Takes the raw CLI string rather than a ``Path`` so that an empty value
+    is distinguishable from an absent flag — ``Path("")`` is ``Path(".")``,
+    which would silently validate the current working directory.
+
+    Only WDL tables are counted. ``_check_syzygy`` calls ``probe_wdl`` and
+    never touches DTZ, and the standard distribution splits tables into
+    sibling ``3-4-5-wdl/`` and ``3-4-5-dtz/`` directories — so a DTZ-only
+    directory is non-empty but still unusable.
+
+    Args:
+        raw_path: The user-supplied ``--syzygy-path`` value.
+
+    Returns:
+        The validated directory as a ``Path``.
+
+    Raises:
+        ValueError: If the value is empty, is not a readable directory, or
+            names a directory containing no WDL tablebase files.
+    """
+    if not raw_path.strip():
+        raise ValueError("Syzygy path is empty")
+
+    path = Path(raw_path)
+    if not path.is_dir():
+        raise ValueError(f"Syzygy path is not a directory: {path}")
+
+    tablebase = chess.syzygy.Tablebase()
+    try:
+        # load_dtz=False so .rtbz files are not counted as usable tables.
+        wdl_count = tablebase.add_directory(str(path), load_dtz=False)
+    except OSError as e:
+        # Path.is_dir() swallows permission errors, so an unreadable
+        # directory only fails here. main() catches ValueError alone.
+        raise ValueError(f"Cannot read Syzygy path {path}: {e}") from e
+    finally:
+        tablebase.close()
+
+    if wdl_count == 0:
+        raise ValueError(f"Syzygy path contains no WDL tablebase files: {path}")
+
+    return path
+
+
 def check_adjudication(
     white_scores: list[int],
     black_scores: list[int],
@@ -227,7 +278,12 @@ def _check_syzygy(
         logger.debug("Syzygy probe failed for position", exc_info=True)
         return None
 
-    if wdl > 0:
+    # probe_wdl returns 2=win, 1=cursed win, 0=draw, -1=blessed loss, -2=loss.
+    # A cursed win / blessed loss is forcible in theory but needs more than
+    # fifty moves to convert, and _play_game() already scores is_fifty_moves()
+    # as an automatic draw — so ±1 are unconvertible here by construction and
+    # must adjudicate as draws. Do not simplify back to wdl > 0 / wdl < 0.
+    if wdl >= 2:
         # Side to move wins
         if board.turn == chess.WHITE:
             return AdjudicationResult(
@@ -239,7 +295,7 @@ def _check_syzygy(
             reason="Syzygy tablebase: black wins",
         )
 
-    if wdl < 0:
+    if wdl <= -2:
         # Side to move loses
         if board.turn == chess.WHITE:
             return AdjudicationResult(
@@ -251,7 +307,7 @@ def _check_syzygy(
             reason="Syzygy tablebase: white wins",
         )
 
-    # WDL == 0: draw
+    # wdl in {-1, 0, 1}: draw (blessed loss, true draw, or cursed win)
     return AdjudicationResult(
         adjudication_type=AdjudicationType.DRAW,
         reason="Syzygy tablebase: draw",

--- a/sprt-runner/src/sprt_runner/runner.py
+++ b/sprt-runner/src/sprt_runner/runner.py
@@ -39,7 +39,7 @@ from shared.time_control import (
 )
 from shared.uci_client import UCIClient
 
-from sprt_runner.adjudication import AdjudicationConfig
+from sprt_runner.adjudication import AdjudicationConfig, validate_syzygy_path
 from sprt_runner.game import GameConfig, play_game
 from sprt_runner.openings import OpeningPair, load_openings, make_opening_pairs
 from sprt_runner.sprt import SPRTDecision, sprt_test
@@ -927,6 +927,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--adjudicate-draw", type=int, default=10, help="Draw adjudication threshold (cp)"
     )
     run_parser.add_argument(
+        "--syzygy-path", type=str, default=None, help="Path to Syzygy tablebase directory"
+    )
+    run_parser.add_argument(
         "--keep-worktrees",
         action="store_true",
         default=False,
@@ -970,9 +973,21 @@ def main() -> None:
         print(format_error_message(str(e)), flush=True)
         sys.exit(1)
 
+    # Unlike --book/--output-dir, an explicitly-supplied path is validated
+    # up front: silently running for hours without the adjudication the user
+    # asked for is worse than refusing to start.
+    syzygy_path: Path | None = None
+    if args.syzygy_path is not None:
+        try:
+            syzygy_path = validate_syzygy_path(args.syzygy_path)
+        except ValueError as e:
+            print(format_error_message(str(e)), flush=True)
+            sys.exit(1)
+
     adjudication = AdjudicationConfig(
         win_threshold_cp=args.adjudicate_win,
         draw_threshold_cp=args.adjudicate_draw,
+        syzygy_path=syzygy_path,
     )
 
     run_config = RunConfig(

--- a/sprt-runner/tests/test_adjudication.py
+++ b/sprt-runner/tests/test_adjudication.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -12,6 +13,7 @@ from sprt_runner.adjudication import (
     AdjudicationConfig,
     AdjudicationType,
     check_adjudication,
+    validate_syzygy_path,
 )
 
 
@@ -326,3 +328,121 @@ class TestSyzygyAdjudication:
             check_adjudication(  # type: ignore[call-arg]
                 [], [], move_number=100, config=config, board=board
             )
+
+    def test_syzygy_cursed_win_is_draw(self, tmp_path: Path) -> None:
+        """WDL == 1 (cursed win): mate is forcible but takes more than fifty
+        moves to convert. play_game() enforces is_fifty_moves() as an automatic
+        draw, so we adjudicate it as a draw rather than a decisive win."""
+        config = AdjudicationConfig(
+            syzygy_path=tmp_path, win_consecutive_moves=0, draw_consecutive_moves=0
+        )
+        board = chess.Board("8/8/8/8/8/8/1k6/KQ6 w - - 0 1")
+        mock_tb = MagicMock()
+        mock_tb.probe_wdl.return_value = 1  # Cursed win
+
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=mock_tb
+        )
+
+        assert result is not None
+        assert result.adjudication_type == AdjudicationType.DRAW
+
+    def test_syzygy_blessed_loss_is_draw(self, tmp_path: Path) -> None:
+        """WDL == -1 (blessed loss): the mirror of a cursed win — the side to
+        move is theoretically lost but the fifty-move rule can save it, so
+        this is a draw, not a decisive loss."""
+        config = AdjudicationConfig(
+            syzygy_path=tmp_path, win_consecutive_moves=0, draw_consecutive_moves=0
+        )
+        board = chess.Board("8/8/8/8/8/8/1k6/KQ6 w - - 0 1")
+        mock_tb = MagicMock()
+        mock_tb.probe_wdl.return_value = -1  # Blessed loss
+
+        result = check_adjudication(
+            [], [], move_number=100, config=config, board=board, tablebase=mock_tb
+        )
+
+        assert result is not None
+        assert result.adjudication_type == AdjudicationType.DRAW
+
+
+class TestValidateSyzygyPath:
+    """Tests for validate_syzygy_path — fail-fast startup validation (issue #173).
+
+    An explicitly-supplied ``--syzygy-path`` that is unusable must fail at
+    startup rather than silently disabling tablebase adjudication for an
+    entire multi-hour SPRT run.
+    """
+
+    def test_nonexistent_path_raises(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(ValueError, match="not a directory"):
+            validate_syzygy_path(str(missing))
+
+    def test_file_not_directory_raises(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "not-a-directory.txt"
+        file_path.write_text("hello")
+        with pytest.raises(ValueError, match="not a directory"):
+            validate_syzygy_path(str(file_path))
+
+    def test_empty_directory_raises(self, tmp_path: Path) -> None:
+        empty_dir = tmp_path / "empty-tables"
+        empty_dir.mkdir()
+        with pytest.raises(ValueError, match="no WDL tablebase files"):
+            validate_syzygy_path(str(empty_dir))
+
+    def test_dtz_only_directory_raises(self, tmp_path: Path) -> None:
+        """A DTZ-only directory has no WDL tables, so every probe would no-op.
+
+        The standard Syzygy distribution splits tables into sibling
+        ``3-4-5-wdl/`` and ``3-4-5-dtz/`` directories, so pointing at the
+        DTZ half is a realistic mistake. ``_check_syzygy`` only ever calls
+        ``probe_wdl``, so such a directory must be rejected even though it
+        is non-empty.
+        """
+        dtz_dir = tmp_path / "3-4-5-dtz"
+        dtz_dir.mkdir()
+        (dtz_dir / "KQvK.rtbz").touch()
+        (dtz_dir / "KRvK.rtbz").touch()
+
+        with pytest.raises(ValueError, match="no WDL tablebase files"):
+            validate_syzygy_path(str(dtz_dir))
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses directory permissions",
+    )
+    def test_unreadable_directory_raises_value_error(self, tmp_path: Path) -> None:
+        """An unreadable directory must surface as ValueError, not OSError.
+
+        ``Path.is_dir()`` swallows the permission error and returns True, so
+        the failure only appears inside ``add_directory``. main() catches
+        ValueError alone, so an escaping PermissionError would exit with a
+        traceback instead of the contracted JSON error line.
+        """
+        locked = tmp_path / "locked"
+        locked.mkdir()
+        locked.chmod(0o000)
+        try:
+            with pytest.raises(ValueError, match="Cannot read Syzygy path"):
+                validate_syzygy_path(str(locked))
+        finally:
+            locked.chmod(0o755)
+
+    def test_empty_value_raises(self) -> None:
+        """``--syzygy-path ""`` must fail rather than silently disable.
+
+        An unset shell variable in a wrapper script (``--syzygy-path
+        "$SYZYGY_DIR"``) is exactly the silent-no-op this flag's validation
+        exists to prevent. Note ``Path("")`` is ``Path(".")``, so this has
+        to be caught before the string becomes a Path.
+        """
+        with pytest.raises(ValueError, match="empty"):
+            validate_syzygy_path("")
+
+    def test_directory_with_wdl_table_returns_path(self, tmp_path: Path) -> None:
+        tb_dir = tmp_path / "tables"
+        tb_dir.mkdir()
+        (tb_dir / "KQvK.rtbw").touch()
+
+        assert validate_syzygy_path(str(tb_dir)) == tb_dir

--- a/sprt-runner/tests/test_runner.py
+++ b/sprt-runner/tests/test_runner.py
@@ -30,6 +30,7 @@ from sprt_runner.runner import (
     format_game_result_message,
     format_interrupted_message,
     format_progress_message,
+    main,
     run_sprt,
     worker_entry,
 )
@@ -1308,6 +1309,158 @@ class TestOutputDirCLI:
             ]
         )
         assert args.output_dir == "/tmp/games"
+
+
+class TestSyzygyPathCLI:
+    """Tests for --syzygy-path CLI argument."""
+
+    def test_syzygy_path_absent(self) -> None:
+        """Without --syzygy-path, the flag should default to None."""
+        parser = build_parser()
+        args = parser.parse_args(["run", "--base", "eng1", "--test", "eng2", "--tc", "depth=1"])
+        assert args.syzygy_path is None
+
+    def test_syzygy_path_present(self) -> None:
+        """With --syzygy-path, the raw string value should be set (not a Path)."""
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--base",
+                "eng1",
+                "--test",
+                "eng2",
+                "--tc",
+                "depth=1",
+                "--syzygy-path",
+                "/tmp/tables",
+            ]
+        )
+        assert args.syzygy_path == "/tmp/tables"
+
+
+class TestMainSyzygyPathWiring:
+    """main()-level tests proving --syzygy-path reaches AdjudicationConfig.
+
+    A parser-level test alone only proves argparse works — the actual bug
+    in issue #173 was the missing kwarg in main()'s AdjudicationConfig(...)
+    call, which parser tests cannot see. These tests patch run_sprt itself
+    and inspect the RunConfig it is handed instead of executing the game
+    loop.
+    """
+
+    def test_syzygy_path_reaches_adjudication_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """--syzygy-path must reach RunConfig.adjudication.syzygy_path."""
+        tb_dir = tmp_path / "tables"
+        tb_dir.mkdir()
+        (tb_dir / "KQvK.rtbw").touch()
+
+        captured: dict[str, RunConfig] = {}
+
+        async def _fake_run_sprt(config: RunConfig) -> None:
+            captured["config"] = config
+
+        monkeypatch.setattr("sprt_runner.runner.run_sprt", _fake_run_sprt)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "sprt_runner",
+                "run",
+                "--base",
+                "eng1",
+                "--test",
+                "eng2",
+                "--tc",
+                "depth=1",
+                "--syzygy-path",
+                str(tb_dir),
+            ],
+        )
+
+        main()
+
+        assert captured["config"].adjudication.syzygy_path == tb_dir
+
+    def test_syzygy_path_absent_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Omitting --syzygy-path must leave syzygy_path as None (default behaviour unchanged)."""
+        captured: dict[str, RunConfig] = {}
+
+        async def _fake_run_sprt(config: RunConfig) -> None:
+            captured["config"] = config
+
+        monkeypatch.setattr("sprt_runner.runner.run_sprt", _fake_run_sprt)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["sprt_runner", "run", "--base", "eng1", "--test", "eng2", "--tc", "depth=1"],
+        )
+
+        main()
+
+        assert captured["config"].adjudication.syzygy_path is None
+
+
+class TestSyzygyPathValidationCLI:
+    """main()-level fail-fast validation of --syzygy-path (issue #173, part B).
+
+    An explicitly-supplied path that is unusable must fail before any game
+    runs, on the same channel (JSON error line on stdout) and with the same
+    exit code as the existing --tc pre-flight check.
+    """
+
+    @staticmethod
+    def _make_bad_path(tmp_path: Path, kind: str) -> str:
+        """Build a --syzygy-path value that must be rejected."""
+        if kind == "missing":
+            return str(tmp_path / "does-not-exist")
+        if kind == "empty-dir":
+            empty_dir = tmp_path / "empty-tables"
+            empty_dir.mkdir()
+            return str(empty_dir)
+        if kind == "dtz-only":
+            dtz_dir = tmp_path / "3-4-5-dtz"
+            dtz_dir.mkdir()
+            (dtz_dir / "KQvK.rtbz").touch()
+            return str(dtz_dir)
+        if kind == "empty-value":
+            return ""
+        raise AssertionError(f"unknown kind: {kind}")
+
+    @pytest.mark.parametrize("kind", ["missing", "empty-dir", "dtz-only", "empty-value"])
+    def test_bad_path_exits_nonzero_with_stdout_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+        kind: str,
+    ) -> None:
+        async def _fail_if_called(config: RunConfig) -> None:
+            raise AssertionError("run_sprt must not be reached when validation fails")
+
+        monkeypatch.setattr("sprt_runner.runner.run_sprt", _fail_if_called)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "sprt_runner",
+                "run",
+                "--base",
+                "eng1",
+                "--test",
+                "eng2",
+                "--tc",
+                "depth=1",
+                "--syzygy-path",
+                self._make_bad_path(tmp_path, kind),
+            ],
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code != 0
+        message = json.loads(capsys.readouterr().out.strip())
+        assert message["type"] == "error"
 
 
 class TestWorktreeCleanupAfterSprt:


### PR DESCRIPTION
Closes #173.

## Why

`AdjudicationConfig.syzygy_path` existed and the whole Syzygy adjudication
path was implemented and tested, but `main()` built its `AdjudicationConfig`
from `--adjudicate-win`/`--adjudicate-draw` only:

```python
adjudication = AdjudicationConfig(
    win_threshold_cp=args.adjudicate_win,
    draw_threshold_cp=args.adjudicate_draw,
)
```

`syzygy_path` was therefore always `None` and the code was unreachable
outside tests. `grep -ci syzygy src/sprt_runner/runner.py` returned 0.

## What changed

**1. The flag.** `--syzygy-path <dir>`, `type=str, default=None`, in-idiom
with `--book`/`--output-dir`, threaded into `AdjudicationConfig.syzygy_path`.
Omitting it leaves `syzygy_path=None`, so default behaviour is unchanged
(AC 2).

**2. Fail-fast validation** (resolving AC 3). An explicitly-supplied path is
checked before any game starts, on the same channel as the existing `--tc`
pre-flight check — JSON error line on stdout, `sys.exit(1)`. Silently
running for hours without the adjudication you asked for is worse than
refusing to start, and three failure modes are otherwise **completely
silent**:

| Input | Before | After |
|---|---|---|
| Nonexistent / not a directory | warns once per game, runs for hours with adjudication off | `exit 1`, `{"type": "error", "message": "Syzygy path is not a directory: …"}` |
| Empty or wrong-nesting-level dir | **opens cleanly**, every probe returns nothing, no diagnostics at all | `exit 1`, `"…contains no WDL tablebase files: …"` |
| DTZ-only dir | **passes any naive check** (non-empty), zero WDL tables loaded, silent no-op | `exit 1`, `"…contains no WDL tablebase files: …"` |
| Unreadable dir (perm 000) | `PermissionError` traceback, empty stdout | `exit 1`, `"Cannot read Syzygy path …"` |
| `--syzygy-path ""` | read as "flag absent", adjudication silently off | `exit 1`, `"Syzygy path is empty"` |

Two of these were found by adversarial review of the first implementation
and reproduced before fixing:

- `chess.syzygy.Tablebase().add_directory()` counts `.rtbz` files. A
  DTZ-only directory returned `3` with `len(tb.wdl) == 0`. The standard
  distribution splits tables into sibling `3-4-5-wdl/` and `3-4-5-dtz/`,
  so pointing at the DTZ half is a realistic mistake — and `_check_syzygy`
  only ever calls `probe_wdl`. `load_dtz=False` discriminates correctly
  (DTZ-only → 0, WDL-only → 1).
- `Path.is_dir()` returns `True` for a perm-000 directory (it swallows the
  `OSError`), so the failure only surfaced inside `add_directory` as a
  `PermissionError` — not a `ValueError`, so it escaped the handler. AC 3
  names "unreadable" explicitly.

The validator takes the raw CLI string rather than a `Path`, because
`Path("")` is `Path(".")` — an empty value would otherwise silently
validate the current working directory.

`_open_tablebase` in `game.py` is **untouched**: its per-game warning is the
right backstop for a path that vanishes mid-run.

**3. Cursed-win / blessed-loss mapping fix.** `_check_syzygy` branched on
`wdl > 0` / `wdl < 0`. `probe_wdl` returns `±1` for a cursed win / blessed
loss: mate is forcible but needs more than fifty moves to convert, and
`_play_game()` already scores `is_fifty_moves()` as an automatic draw — so
those positions are unconvertible here by construction. Both were being
scored as decisive results, which biases the very Elo estimate SPRT exists
to measure. No test covered `±1`.

Folded in rather than filed separately because this PR is what makes the
path reachable in production for the first time.

## Verification

**Mutation testing — 8 deliberate mutations, 0 survivors.** Each was applied
to source only, the suite run, then reverted (source verified byte-identical
afterwards):

| Mutation | Killed by |
|---|---|
| Drop `syzygy_path=` from `AdjudicationConfig(...)` — *the exact bug #173 reports* | 1 test |
| `wdl >= 2` → `wdl > 0` (reintroduce cursed-win bug) | 1 |
| `wdl <= -2` → `wdl < 0` (reintroduce blessed-loss bug) | 1 |
| Zero-table check can never fire | 2 |
| Remove the `is_dir()` guard | 3 |
| Drop `load_dtz=False` | 2 |
| Drop the `OSError` → `ValueError` conversion | 1 |
| Drop the empty-value guard | 1 |

The first is load-bearing and is killed by **exactly one** test:
`TestMainSyzygyPathWiring::test_syzygy_path_reaches_adjudication_config`.
Both parser-level tests pass with the bug fully present — `parse_args` only
proves argparse works. That test is the only thing standing between the repo
and a regression of the reported bug; please don't delete it as "redundant".

**Live CLI**, all five bad-path shapes exit 1 with a clean JSON error line
and no traceback. A valid WDL directory passes validation and proceeds to
the same point as no flag at all.

```
196 passed, 2 deselected   (179 baseline + 17 new)
pyright: 0 errors, 0 warnings, 0 informations
ruff 0.16.1 check: All checks passed
ruff 0.16.1 format --check: 90 files already formatted
```

Diff is `sprt-runner/` only, +348/−4. All four deleted lines are in source —
**zero deletions in the test files**, so no existing assertion was loosened.

## Caveats

- **All tests are mock-based.** There are no Syzygy tables on the dev
  machine and python-chess ships none, so the flag is inert until a table
  set is fetched. The failure modes above were each reproduced against real
  synthetic directories, but no real probe was ever run.
- **Known, deliberately out of scope:** `_check_syzygy` ignores
  `board.halfmove_clock`, so a `±2` result can still adjudicate as decisive
  when playing on would have drawn. Pre-existing, needs `probe_dtz`, and is
  its own issue.
- Backend exposure is **deliberately not here** — resolved as runner-only
  and deferred to #178, which also records the ordering dependency on the
  stuck-`RUNNING` bug in `_monitor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)