### PR TITLE
fix: write a terminal status when the SPRT runner exits without completing

### DIFF
--- a/backend/src/backend/services/sprt_service.py
+++ b/backend/src/backend/services/sprt_service.py
@@ -59,6 +59,9 @@ class _RunningTest:
         subscribers: WebSocket queues awaiting updates.
         monitor_task: Background task reading stdout JSON-lines.
         stderr_task: Background task draining stderr.
+        cancel_requested: Whether we signalled this run to stop. Lets
+            :meth:`SPRTService._monitor` tell a deliberate cancel from a
+            crash even when the runner dies before saying anything.
     """
 
     test_id: str
@@ -69,6 +72,7 @@ class _RunningTest:
     )
     monitor_task: asyncio.Task[None] | None = None
     stderr_task: asyncio.Task[None] | None = None
+    cancel_requested: bool = False
 
 
 class SPRTService:
@@ -257,6 +261,7 @@ class SPRTService:
 
         try:
             running.process.send_signal(signal.SIGTERM)
+            running.cancel_requested = True
             logger.info("Sent SIGTERM to SPRT test %s", test_id)
             return True
         except ProcessLookupError:
@@ -302,6 +307,7 @@ class SPRTService:
     async def shutdown(self) -> None:
         """Terminate all running SPRT subprocesses."""
         for running in list(self._running.values()):
+            running.cancel_requested = True
             try:
                 running.process.terminate()
                 await asyncio.wait_for(running.process.wait(), timeout=5.0)
@@ -313,8 +319,21 @@ class SPRTService:
     # -- internal ---------------------------------------------------------
 
     async def _monitor(self, running: _RunningTest) -> None:
-        """Read JSON-lines from the subprocess stdout and dispatch updates."""
+        """Read JSON-lines from the subprocess stdout and dispatch updates.
+
+        The runner emits ``complete`` only when SPRT reaches a decision, and
+        ``interrupted`` only on SIGINT/SIGTERM. Every other way it can stop —
+        a fail-fast startup error, every worker dying (which exits 0), a
+        SIGKILL — produces no terminal message at all, so the terminal status
+        is decided from process exit rather than from the stream.
+
+        ``error`` deliberately does not end the test: the runner emits one per
+        dead worker and per failed game and then carries on, so treating it as
+        terminal would fail tests that go on to reach a decision.
+        """
         assert running.process.stdout is not None
+
+        final_status: SPRTStatus | None = None
 
         try:
             while True:
@@ -347,8 +366,12 @@ class SPRTService:
                     self._update_test_from_progress(running)
 
                 elif msg_type == "complete":
-                    result_str = msg.get("result", "")
-                    self._complete_test(running, result_str)
+                    final_status = SPRTStatus.COMPLETED
+                    self._finalise_test(running, final_status, msg.get("result", ""))
+
+                elif msg_type == "interrupted":
+                    final_status = SPRTStatus.CANCELLED
+                    self._finalise_test(running, final_status)
 
                 # Broadcast to subscribers
                 for queue in running.subscribers:
@@ -359,6 +382,23 @@ class SPRTService:
         finally:
             await running.process.wait()
             self._running.pop(running.test_id, None)
+
+            if final_status is None:
+                final_status = (
+                    SPRTStatus.CANCELLED if running.cancel_requested else SPRTStatus.FAILED
+                )
+                logger.warning(
+                    "SPRT test %s ended without a terminal message (exit=%s); marking %s",
+                    running.test_id,
+                    running.process.returncode,
+                    final_status.value,
+                )
+                self._finalise_test(running, final_status)
+
+            # Subscribers block on an empty queue, so the WebSocket handler
+            # needs an explicit end-of-stream to close on.
+            for queue in running.subscribers:
+                queue.put_nowait({"type": "test_finished", "status": final_status.value})
 
     async def _drain_stderr(self, running: _RunningTest) -> None:
         """Read and log stderr from the SPRT runner subprocess to prevent pipe deadlock."""
@@ -402,8 +442,18 @@ class SPRTService:
         except KeyError:
             logger.warning("Test %s not found during progress update", running.test_id)
 
-    def _complete_test(self, running: _RunningTest, result_str: str) -> None:
-        """Mark a test as completed in the repository."""
+    def _finalise_test(
+        self, running: _RunningTest, status: SPRTStatus, result_str: str = ""
+    ) -> None:
+        """Write a terminal *status* for a test to the repository.
+
+        Args:
+            running: The test whose run has ended.
+            status: Terminal status to persist.
+            result_str: SPRT outcome from a ``complete`` message, if any.
+                Only ``complete`` carries one; every other terminal path
+                leaves ``result`` null.
+        """
         test = self._test_repo.get_sprt_test(running.test_id)
         if test is None:
             return
@@ -422,7 +472,7 @@ class SPRTService:
             alpha=test.alpha,
             beta=test.beta,
             created_at=test.created_at,
-            status=SPRTStatus.COMPLETED,
+            status=status,
             wins=running.progress.wins,
             losses=running.progress.losses,
             draws=running.progress.draws,
@@ -433,4 +483,4 @@ class SPRTService:
         try:
             self._test_repo.update_sprt_results(updated)
         except KeyError:
-            logger.warning("Test %s not found during completion", running.test_id)
+            logger.warning("Test %s not found during finalisation", running.test_id)

--- a/backend/src/backend/ws/sprt.py
+++ b/backend/src/backend/ws/sprt.py
@@ -24,10 +24,10 @@ async def sprt_progress_websocket(websocket: WebSocket, test_id: str) -> None:
 
     Connects to the SPRT service's subscriber queue and forwards
     each JSON-lines message (progress, game_result, complete, error)
-    to the client.
+    to the client, plus the service's own ``test_finished`` message
+    carrying the test's terminal status.
 
-    The WebSocket closes when the test completes or the client
-    disconnects.
+    The WebSocket closes when the run ends or the client disconnects.
     """
     await websocket.accept()
 
@@ -44,7 +44,10 @@ async def sprt_progress_websocket(websocket: WebSocket, test_id: str) -> None:
             msg: dict[str, Any] = await queue.get()
             await websocket.send_json(msg)
 
-            if msg.get("type") == "complete":
+            # "complete" ends a run that reached an SPRT decision;
+            # "test_finished" ends every other one, including the runs that
+            # fail or are cancelled and so never emit "complete" at all.
+            if msg.get("type") in ("complete", "test_finished"):
                 break
     except WebSocketDisconnect:
         logger.info("SPRT WebSocket disconnected for test %s", test_id)

--- a/backend/tests/test_sprt_service.py
+++ b/backend/tests/test_sprt_service.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import backend.services.sprt_service as _sprt_mod
@@ -99,6 +102,194 @@ class TestSPRTServiceProperties:
         service = SPRTService(repo)
         result = await service.cancel_test("nonexistent")
         assert result is False
+
+
+def _json_line(**fields: Any) -> bytes:
+    """Encode *fields* as one JSON-lines message from the runner."""
+    return json.dumps(fields).encode() + b"\n"
+
+
+class TestSPRTServiceMonitorTerminalStatus:
+    """Tests that ``_monitor`` always writes a terminal status.
+
+    The runner emits ``complete`` only when SPRT reaches a decision. Every
+    other way it can stop — a fatal error, every worker dying (which exits
+    0), SIGTERM, SIGKILL — used to leave the record at ``RUNNING`` forever,
+    un-cancellable because ``_running`` had already been popped.
+    """
+
+    @pytest.fixture
+    def sprt_repo(self) -> MagicMock:
+        repo = MagicMock()
+        repo.get_sprt_test = MagicMock(
+            return_value=SPRTTest(
+                id="test-1",
+                engine_a="a",
+                engine_b="b",
+                time_control=FixedTimeControl(movetime_ms=100),
+                elo0=0.0,
+                elo1=5.0,
+                alpha=0.05,
+                beta=0.05,
+                created_at=datetime(2024, 1, 1, tzinfo=UTC),
+                status=SPRTStatus.RUNNING,
+            )
+        )
+        repo.update_sprt_results = MagicMock()
+        return repo
+
+    @staticmethod
+    def _running(lines: list[bytes], *, returncode: int = 0) -> Any:
+        stdout = MagicMock()
+        stdout.readline = AsyncMock(side_effect=[*lines, b""])
+        process = MagicMock()
+        process.stdout = stdout
+        process.wait = AsyncMock(return_value=returncode)
+        process.returncode = returncode
+        return _RunningTest(test_id="test-1", process=process)
+
+    @staticmethod
+    def _final_status(sprt_repo: MagicMock) -> SPRTStatus:
+        assert sprt_repo.update_sprt_results.call_args is not None
+        status: SPRTStatus = sprt_repo.update_sprt_results.call_args[0][0].status
+        return status
+
+    @pytest.mark.asyncio
+    async def test_complete_marks_completed(self, sprt_repo: MagicMock) -> None:
+        running = self._running([_json_line(type="complete", result="H1", total_games=10, llr=3.0)])
+        service = SPRTService(sprt_repo)
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert self._final_status(sprt_repo) == SPRTStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_interrupted_marks_cancelled(self, sprt_repo: MagicMock) -> None:
+        """SIGTERM from cancel_test makes the runner emit ``interrupted``."""
+        running = self._running([_json_line(type="interrupted", games_played=4)], returncode=1)
+        service = SPRTService(sprt_repo)
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert self._final_status(sprt_repo) == SPRTStatus.CANCELLED
+
+    @pytest.mark.asyncio
+    async def test_fatal_error_exit_marks_failed(self, sprt_repo: MagicMock) -> None:
+        """A fail-fast runner exit emits ``error`` and never ``complete``."""
+        running = self._running(
+            [_json_line(type="error", message="Failed to resolve engines: no such engine")],
+            returncode=1,
+        )
+        service = SPRTService(sprt_repo)
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert self._final_status(sprt_repo) == SPRTStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_without_complete_marks_failed(self, sprt_repo: MagicMock) -> None:
+        """An all-workers-died abort breaks the runner's loop but still exits 0."""
+        running = self._running(
+            [_json_line(type="error", message="All workers died unexpectedly")],
+            returncode=0,
+        )
+        service = SPRTService(sprt_repo)
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert self._final_status(sprt_repo) == SPRTStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_silent_death_marks_failed(self, sprt_repo: MagicMock) -> None:
+        """SIGKILL leaves no output at all."""
+        running = self._running([], returncode=-9)
+        service = SPRTService(sprt_repo)
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert self._final_status(sprt_repo) == SPRTStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_silent_death_after_cancel_marks_cancelled(self, sprt_repo: MagicMock) -> None:
+        """A cancelled run that dies before emitting ``interrupted`` is still a cancel."""
+        running = self._running([], returncode=-15)
+        running.cancel_requested = True
+        service = SPRTService(sprt_repo)
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert self._final_status(sprt_repo) == SPRTStatus.CANCELLED
+
+    @pytest.mark.asyncio
+    async def test_nonfatal_error_does_not_end_the_test(self, sprt_repo: MagicMock) -> None:
+        """``error`` is per-game and non-fatal at 2 of its 4 runner call sites.
+
+        A single dead worker must not mark the whole test FAILED — the runner
+        carries on and can still reach a decision.
+        """
+        running = self._running(
+            [
+                _json_line(type="error", message="Worker for game g1 died unexpectedly (pid=7)"),
+                _json_line(type="progress", wins=5, losses=3, draws=2, llr=1.0, games_total=10),
+                _json_line(type="complete", result="H1", total_games=10, llr=3.0),
+            ]
+        )
+        service = SPRTService(sprt_repo)
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert self._final_status(sprt_repo) == SPRTStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_broadcasts_test_finished_to_subscribers(self, sprt_repo: MagicMock) -> None:
+        """Without a terminal message the WS handler's queue.get() blocks forever."""
+        running = self._running([_json_line(type="error", message="boom")], returncode=1)
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        running.subscribers.append(queue)
+        service = SPRTService(sprt_repo)
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert queue.get_nowait()["type"] == "error"
+        finished = queue.get_nowait()
+        assert finished["type"] == "test_finished"
+        assert finished["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_removes_test_from_running(self, sprt_repo: MagicMock) -> None:
+        running = self._running([], returncode=1)
+        service = SPRTService(sprt_repo)
+        service._running["test-1"] = running  # pyright: ignore[reportPrivateUsage]
+
+        await service._monitor(running)  # pyright: ignore[reportPrivateUsage]
+
+        assert service.running_tests == []
+
+
+class TestSPRTServiceCancelFlag:
+    """Tests that a deliberate cancel is distinguishable from a crash."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_test_records_the_request(self) -> None:
+        process = MagicMock()
+        process.send_signal = MagicMock()
+        running = _RunningTest(test_id="test-1", process=process)
+        service = SPRTService(MagicMock())
+        service._running["test-1"] = running  # pyright: ignore[reportPrivateUsage]
+
+        assert await service.cancel_test("test-1") is True
+        assert running.cancel_requested is True
+
+    @pytest.mark.asyncio
+    async def test_failed_signal_does_not_record_a_cancel(self) -> None:
+        process = MagicMock()
+        process.send_signal = MagicMock(side_effect=ProcessLookupError)
+        running = _RunningTest(test_id="test-1", process=process)
+        service = SPRTService(MagicMock())
+        service._running["test-1"] = running  # pyright: ignore[reportPrivateUsage]
+
+        assert await service.cancel_test("test-1") is False
+        assert running.cancel_requested is False
 
 
 class TestSPRTServiceStderr:

--- a/backend/tests/test_ws_sprt.py
+++ b/backend/tests/test_ws_sprt.py
@@ -84,6 +84,35 @@ class TestSPRTWebSocket:
 
         mock_sprt_service.unsubscribe.assert_called_once()
 
+    def test_test_finished_closes_the_stream(
+        self,
+        ws_client: TestClient,
+        mock_sprt_service: MagicMock,
+    ) -> None:
+        """A run that ends without ``complete`` must still close the socket.
+
+        ``queue.get()`` blocks forever otherwise, leaking the connection and
+        its subscriber entry for every test that fails or is cancelled.
+        """
+        mock_queue = AsyncMock()
+        mock_queue.get = AsyncMock(
+            side_effect=[
+                {"type": "error", "message": "Failed to resolve engines"},
+                {"type": "test_finished", "status": "failed"},
+            ]
+        )
+        mock_sprt_service.subscribe = MagicMock(return_value=mock_queue)
+
+        with ws_client.websocket_connect("/ws/sprt/test-fail") as ws:
+            error = ws.receive_json()
+            finished = ws.receive_json()
+
+        assert error["type"] == "error"
+        assert finished["type"] == "test_finished"
+        assert finished["status"] == "failed"
+        assert mock_queue.get.await_count == 2
+        mock_sprt_service.unsubscribe.assert_called_once()
+
     def test_multiple_progress_messages_relayed(
         self,
         ws_client: TestClient,

--- a/frontend/src/components/SPRTDashboard/SPRTDashboard.test.tsx
+++ b/frontend/src/components/SPRTDashboard/SPRTDashboard.test.tsx
@@ -50,6 +50,36 @@ describe('SPRTDashboard', () => {
     expect(screen.getByText('No SPRT tests yet.')).toBeInTheDocument()
   })
 
+  it('badges a failed test distinctly from a cancelled one', () => {
+    render(
+      <SPRTDashboard
+        tests={[
+          makeTest({ id: 't1', status: 'failed' }),
+          makeTest({ id: 't2', status: 'cancelled' }),
+        ]}
+        onCancel={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    const failed = screen.getByText('failed')
+    const cancelled = screen.getByText('cancelled')
+    expect(failed).toBeInTheDocument()
+    expect(cancelled).toBeInTheDocument()
+    expect(failed.className).not.toEqual(cancelled.className)
+  })
+
+  it('offers no cancel button for a failed test', () => {
+    render(
+      <SPRTDashboard
+        tests={[makeTest({ status: 'failed' })]}
+        onCancel={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+  })
+
   it('renders a table row per test with W/D/L, LLR, engine pair', () => {
     const tests = [
       makeTest({

--- a/frontend/src/components/SPRTDashboard/SPRTDashboard.tsx
+++ b/frontend/src/components/SPRTDashboard/SPRTDashboard.tsx
@@ -11,6 +11,7 @@ function statusBadge(status: string): React.JSX.Element {
     running: 'bg-blue-600 text-blue-100',
     completed: 'bg-green-700 text-green-100',
     cancelled: 'bg-gray-600 text-gray-200',
+    failed: 'bg-red-800 text-red-100',
   }
   const cls = colors[status] ?? 'bg-gray-600 text-gray-200'
   return (

--- a/frontend/src/pages/SPRTTestsPage.test.tsx
+++ b/frontend/src/pages/SPRTTestsPage.test.tsx
@@ -536,6 +536,70 @@ describe('SPRTTestsPage', () => {
     })
   })
 
+  it('marks the row failed when the run ends without completing', async () => {
+    render(<SPRTTestsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('engine-1 vs engine-2')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('10 / 3 / 5'))
+
+    act(() => {
+      capturedOnMessage?.({ type: 'test_finished', status: 'failed' })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('failed')).toBeInTheDocument()
+    })
+    // A finished run must not still offer to cancel itself.
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+    // ...and this one really is the end of the stream.
+    expect(vi.mocked(useWebSocket).mock.calls.at(-1)?.[0]).toBeNull()
+  })
+
+  it('marks the row cancelled when the run ends as cancelled', async () => {
+    render(<SPRTTestsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('engine-1 vs engine-2')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('10 / 3 / 5'))
+
+    act(() => {
+      capturedOnMessage?.({ type: 'test_finished', status: 'cancelled' })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('cancelled')).toBeInTheDocument()
+    })
+  })
+
+  it('keeps the row running when a non-fatal error arrives', async () => {
+    // The runner emits "error" per dead worker and carries on, so an error
+    // alone must not retire the row.
+    render(<SPRTTestsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('engine-1 vs engine-2')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('10 / 3 / 5'))
+
+    act(() => {
+      capturedOnMessage?.({ type: 'error', message: 'Worker for game g1 died' })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Worker for game g1 died')).toBeInTheDocument()
+    })
+    expect(screen.getByText('running')).toBeInTheDocument()
+    // The stream must stay open — the run is still going, and closing it here
+    // would blank the live view for the rest of the test.
+    expect(vi.mocked(useWebSocket).mock.calls.at(-1)?.[0]).not.toBeNull()
+  })
+
   it('shows error from WebSocket error message', async () => {
     render(<SPRTTestsPage />)
 

--- a/frontend/src/pages/SPRTTestsPage.tsx
+++ b/frontend/src/pages/SPRTTestsPage.tsx
@@ -36,7 +36,20 @@ interface WsErrorMessage {
   message: string
 }
 
-type WsSprtMessage = WsProgressMessage | WsCompleteMessage | WsErrorMessage
+/**
+ * End-of-stream message carrying the test's terminal status.
+ *
+ * The backend sends this once the runner process has exited, on every path
+ * including the ones that never emit `complete` — a fatal error, every
+ * worker dying, a cancel, a kill. `error` is not a substitute: the runner
+ * emits it per dead worker and then carries on.
+ */
+interface WsTestFinishedMessage {
+  type: 'test_finished'
+  status: string
+}
+
+type WsSprtMessage = WsProgressMessage | WsCompleteMessage | WsErrorMessage | WsTestFinishedMessage
 
 // ---------------------------------------------------------------------------
 // Live progress state
@@ -250,6 +263,10 @@ export function SPRTTestsPage(): React.JSX.Element {
         setWsUrl(null)
       } else if (msg.type === 'error') {
         setError(msg.message)
+      } else if (msg.type === 'test_finished') {
+        setTests((prev) =>
+          prev.map((t) => (t.id === activeTestId ? { ...t, status: msg.status } : t)),
+        )
         setWsUrl(null)
       }
     },

--- a/shared/src/shared/storage/models.py
+++ b/shared/src/shared/storage/models.py
@@ -28,11 +28,19 @@ class GameResult(Enum):
 
 
 class SPRTStatus(Enum):
-    """Lifecycle status of an SPRT test."""
+    """Lifecycle status of an SPRT test.
+
+    ``CANCELLED`` means the run was deliberately stopped — by the user, or
+    by a backend restart that orphaned the subprocess. ``FAILED`` means it
+    stopped for any other reason: a fatal runner error, all workers dying,
+    or the process being killed. The two are kept apart because "I stopped
+    this" and "this broke" call for different follow-up.
+    """
 
     RUNNING = "running"
     COMPLETED = "completed"
     CANCELLED = "cancelled"
+    FAILED = "failed"
 
 
 class SPRTOutcome(Enum):

--- a/shared/tests/test_file_store.py
+++ b/shared/tests/test_file_store.py
@@ -357,6 +357,14 @@ class TestFileSPRTTestRepositoryRoundTrip:
         assert loaded.result == SPRTOutcome.H1
         assert loaded.completed_at == completed
 
+    def test_round_trip_preserves_failed_status(self, tmp_path: Path) -> None:
+        repo = FileSPRTTestRepository(tmp_path)
+        repo.save_sprt_test(_make_sprt_test("test-003", status=SPRTStatus.FAILED))
+
+        loaded = repo.get_sprt_test("test-003")
+        assert loaded is not None
+        assert loaded.status == SPRTStatus.FAILED
+
     def test_creates_meta_json(self, tmp_path: Path) -> None:
         repo = FileSPRTTestRepository(tmp_path)
         repo.save_sprt_test(_make_sprt_test())

--- a/shared/tests/test_storage_models.py
+++ b/shared/tests/test_storage_models.py
@@ -201,6 +201,7 @@ class TestSPRTEnums:
         assert SPRTStatus.RUNNING.value == "running"
         assert SPRTStatus.COMPLETED.value == "completed"
         assert SPRTStatus.CANCELLED.value == "cancelled"
+        assert SPRTStatus.FAILED.value == "failed"
 
     def test_outcome_values(self) -> None:
         assert SPRTOutcome.H0.value == "H0"


### PR DESCRIPTION
Closes #180. Unblocks #178.

`SPRTService._monitor` branched only on `progress` and `complete`, and its
`finally` wrote no status. The runner emits `complete` **only** when SPRT
reaches a decision, so every other ending left the record at `status=running`
forever — un-cancellable, because the `finally` had already popped `_running`
and `cancel_test` therefore 404s. Only a backend restart cleared it.

The **Cancel button was the common case**, not an edge case. The frontend
optimistically painted the row `cancelled`, so it looked like it worked until
a reload brought the row back as `running` with a live Cancel button that 404s.

## Why the status comes from process exit, not from the stream

Three things rule out the obvious message-based fix. All were confirmed by
running the real runner, not just by reading it.

- **`error` is not fatal.** The runner emits one per dead worker and per
  failed game and then carries on — 2 of its 4 in-loop call sites `continue`.
  Mapping `error` to a terminal status fails tests that still reach a decision.
- **Failure can exit 0.** `run_sprt` returns normally after "All workers died
  unexpectedly" and after a failed engine resolution (`runner.py:593` prints
  the error, then `return`s), so `main()` exits **0** with no `complete`. A
  returncode check alone misses the runner's likeliest startup failure.
- **`interrupted` is not guaranteed on SIGTERM.** When the signal landed during
  engine setup the runner died outside the handler's `try` and emitted nothing.
  A `cancel_requested` flag on `_RunningTest` records the intent instead — it
  is load-bearing, not belt-and-braces.

## Changes

| Component | Change |
|---|---|
| `shared/` | `SPRTStatus.FAILED`, so "I stopped this" and "this broke" stay apart |
| `backend/` | `_monitor` always writes a terminal status; `cancel_requested` on `_RunningTest`; `_complete_test` generalised to `_finalise_test`; new `test_finished` WS message |
| `backend/` | `ws/sprt.py` breaks on `test_finished` too — it previously blocked on `queue.get()` forever, leaking the socket and its subscriber entry for every failed or cancelled test |
| `frontend/` | `test_finished` handled, red `failed` badge, and `error` no longer tears down the live stream |

Mapping: `complete` → COMPLETED, `interrupted` → CANCELLED, exit with no
terminal message → CANCELLED if we signalled it, else FAILED.

`recover_on_startup` still writes CANCELLED for tests orphaned by a backend
restart — deliberately left alone, since changing it would rewrite the meaning
of existing records.

## Verification

`make lint` and `make test` green: 187 shared, 196 backend, 28 runner, 275
frontend.

**12 deliberate mutations, 12 killed**, sources restored byte-identical.
Includes the two tempting wrong fixes: treating `error` as terminal (killed by
3 tests) and dropping the `finally` fallback (killed by 5).

**Live against the real runner subprocess** — bad engine id → `failed`,
UI cancel → `cancelled`, decision reached → `completed`.

**Live in a real browser** — created a test, watched it stream 68 games over
the WebSocket, `kill -9`'d the runner. The row flipped to a red `failed` with
the Cancel button gone, **and stayed `failed` through a full page reload** —
which is exactly where the bug used to resurface. Cancelling through the UI
likewise now reads `cancelled` after reload instead of reverting to `running`.
No console errors; the backend logged
`ended without a terminal message (exit=-9); marking failed`.

Note the usual caveat: the integration jobs only run on push to `main`, so
CI on this PR does not cover the runner end-to-end. The manual runs above are
the strongest evidence available pre-merge.

## Contract note

`SPRTStatus.FAILED` is a storage-model change, but not an API break —
`SPRTTestResponse.status` and the frontend's `SPRTTest.status` are both plain
`string`, and `statusBadge` already fell back to gray for unknown values. The
`test_finished` WS message is a genuine addition to the socket contract; it
carries only `{type, status}`, no paths or exception text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
